### PR TITLE
Closing the InputStream to release resources that it might be holding.

### DIFF
--- a/src/main/java/com/vdurmont/emoji/EmojiManager.java
+++ b/src/main/java/com/vdurmont/emoji/EmojiManager.java
@@ -34,6 +34,7 @@ public class EmojiManager {
                     EMOJIS_BY_ALIAS.put(alias, emoji);
                 }
             }
+            stream.close();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Reason: besides the above stated, using this library and StrictMode on Android lead to crashes due to the fact that this InputStream is not closed.

More at http://developer.android.com/reference/android/os/StrictMode.VmPolicy.Builder.html#detectLeakedClosableObjects() and http://stackoverflow.com/questions/9547843/do-i-need-to-close-an-inputstream-in-java