### PR TITLE
Much much faster emoji parsing to unicode!

### DIFF
--- a/src/main/java/com/vdurmont/emoji/EmojiManager.java
+++ b/src/main/java/com/vdurmont/emoji/EmojiManager.java
@@ -16,8 +16,12 @@ import java.util.Set;
  */
 public class EmojiManager {
     private static final String PATH = "/emojis-2014-12-11.json";
+    
     private static final Map<String, Emoji> EMOJIS_BY_ALIAS = new HashMap<String, Emoji>();
     private static final Map<String, Set<Emoji>> EMOJIS_BY_TAG = new HashMap<String, Set<Emoji>>();
+
+    private static final Map<String, String> UNICODE_BY_HTML_HEXADECIMAL = new HashMap<String, String>();
+    private static final Map<String, String> UNICODE_BY_HTML_DECIMAL = new HashMap<String, String>();
 
     static {
         try {
@@ -33,6 +37,10 @@ public class EmojiManager {
                 for (String alias : emoji.getAliases()) {
                     EMOJIS_BY_ALIAS.put(alias, emoji);
                 }
+                
+                
+                UNICODE_BY_HTML_HEXADECIMAL.put(emoji.getHtmlHexidecimal(), emoji.getUnicode());
+                UNICODE_BY_HTML_DECIMAL.put(emoji.getHtmlDecimal(), emoji.getUnicode());
             }
             stream.close();
         } catch (IOException e) {
@@ -66,6 +74,20 @@ public class EmojiManager {
             return null;
         }
         return EMOJIS_BY_ALIAS.get(trimAlias(alias));
+    }
+    
+    public static String getUnicodeForHtmlHexadecimal(String htmlHexadecimal) {
+        if (htmlHexadecimal == null) {
+            return null;
+        }
+        return UNICODE_BY_HTML_HEXADECIMAL.get(htmlHexadecimal);
+    }
+    
+    public static String getUnicodeForHtmlDecimal(String htmlDecimal) {
+        if (htmlDecimal == null) {
+            return null;
+        }
+        return UNICODE_BY_HTML_DECIMAL.get(htmlDecimal);
     }
 
     private static String trimAlias(String alias) {

--- a/src/main/java/com/vdurmont/emoji/EmojiManager.java
+++ b/src/main/java/com/vdurmont/emoji/EmojiManager.java
@@ -38,7 +38,6 @@ public class EmojiManager {
                     EMOJIS_BY_ALIAS.put(alias, emoji);
                 }
                 
-                
                 UNICODE_BY_HTML_HEXADECIMAL.put(emoji.getHtmlHexidecimal(), emoji.getUnicode());
                 UNICODE_BY_HTML_DECIMAL.put(emoji.getHtmlDecimal(), emoji.getUnicode());
             }

--- a/src/main/java/com/vdurmont/emoji/EmojiParser.java
+++ b/src/main/java/com/vdurmont/emoji/EmojiParser.java
@@ -54,8 +54,16 @@ public class EmojiParser {
         Matcher matcher = pattern.matcher(result);
         while (matcher.find()) {
             String match = matcher.group(0);
-            result = result.replace(match, EmojiManager.getUnicodeForHtmlHexadecimal(match));
-            result = result.replace(match, EmojiManager.getUnicodeForHtmlDecimal(match));
+            
+            final String unicodeForHtmlHexadecimal = EmojiManager.getUnicodeForHtmlHexadecimal(match);
+            if (unicodeForHtmlHexadecimal != null) {
+                result = result.replace(match, unicodeForHtmlHexadecimal);
+            }
+            
+            final String unicodeForHtmlDecimal = EmojiManager.getUnicodeForHtmlDecimal(match);
+            if (unicodeForHtmlDecimal != null) {
+                result = result.replace(match, unicodeForHtmlDecimal);
+            }
         }
 
         return result;

--- a/src/main/java/com/vdurmont/emoji/EmojiParser.java
+++ b/src/main/java/com/vdurmont/emoji/EmojiParser.java
@@ -50,9 +50,12 @@ public class EmojiParser {
         }
 
         // Replace the html
-        for (Emoji emoji : EmojiManager.getAll()) {
-            result = result.replace(emoji.getHtmlHexidecimal(), emoji.getUnicode());
-            result = result.replace(emoji.getHtml(), emoji.getUnicode());
+        Pattern pattern = Pattern.compile("(&#)\\w+(;)");
+        Matcher matcher = pattern.matcher(result);
+        while (matcher.find()) {
+            String match = matcher.group(0);
+            result = result.replace(match, EmojiManager.getUnicodeForHtmlHexadecimal(match));
+            result = result.replace(match, EmojiManager.getUnicodeForHtmlDecimal(match));
         }
 
         return result;


### PR DESCRIPTION
Instead of looping over all the emojis, and replacing emoji's htmlHexadecimal code and htmlDecimal code by the unicode symbol in `parseToUnicode()`, search using regex for all substrings matching &#anything; and for each match (key in the hashmap), see if it is in either UNICODE_BY_HTML_HEXADECIMAL or UNICODE_BY_HTML_DECIMAL and return its matching value (in the hashmap)