### PR TITLE
Alias overlap fix

### DIFF
--- a/src/main/resources/emojis.json
+++ b/src/main/resources/emojis.json
@@ -10864,7 +10864,7 @@
     "description": "dark sunglasses",
     "supports_fitzpatrick": false,
     "aliases": [
-      "sunglasses"
+      "dark_sunglasses"
     ],
     "tags": []
   },


### PR DESCRIPTION
Altered an alias so the Smiling Face With Sunglasses emoji parses correctly.

Both "dark sunglasses" and "Smiling Face With Sunglasses" had the same alias, "sunglasses." This caused the Smiling Face With Sunglasses emoji to never get replaced with its :string: in EmojiParser:ParseToAliases