### PR TITLE
Significantly faster unicode replace

### DIFF
--- a/src/main/java/com/vdurmont/emoji/Emoji.java
+++ b/src/main/java/com/vdurmont/emoji/Emoji.java
@@ -1,7 +1,6 @@
 package com.vdurmont.emoji;
 
 import java.io.UnsupportedEncodingException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -150,6 +149,16 @@ public class Emoji {
      */
     public String getHtmlHexidecimal() {
         return this.htmlHex;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return !(other == null || !(other instanceof Emoji)) && ((Emoji) other).getUnicode().equals(getUnicode());
+    }
+
+    @Override
+    public int hashCode() {
+        return unicode.hashCode();
     }
 
     /**

--- a/src/main/java/com/vdurmont/emoji/EmojiTrie.java
+++ b/src/main/java/com/vdurmont/emoji/EmojiTrie.java
@@ -21,15 +21,17 @@ public class EmojiTrie {
 
     /**
      * Checks if sequence of chars contain an emoji.
-     * @param emojiSequence Sequence of char that may contain emoji in full or partially.
-     * @return Returns
-     * Matches.EXACTLY if char sequence in its entirety is an emoji
-     * Matches.POSSIBLY if char sequence matches prefix of an emoji
-     * Matches.IMPOSSIBLE if char sequence matches no emoji or prefix of an emoji
+     * @param sequence Sequence of char that may contain emoji in full or partially.
+     * @return
+     * <li>Matches.EXACTLY if char sequence in its entirety is an emoji</li>
+     * <li>Matches.POSSIBLY if char sequence matches prefix of an emoji</li>
+     * <li>Matches.IMPOSSIBLE if char sequence matches no emoji or prefix of an emoji</li>
      */
-    public Matches isEmoji(char[] emojiSequence) {
+    public Matches isEmoji(char[] sequence) {
+        if(sequence == null) return Matches.POSSIBLY;
+
         Node tree = root;
-        for(char c: emojiSequence) {
+        for(char c: sequence) {
             if(! tree.hasChild(c)) {
                 return Matches.IMPOSSIBLE;
             }

--- a/src/main/java/com/vdurmont/emoji/EmojiTrie.java
+++ b/src/main/java/com/vdurmont/emoji/EmojiTrie.java
@@ -1,0 +1,99 @@
+package com.vdurmont.emoji;
+
+import java.util.*;
+
+public class EmojiTrie {
+    private Node root = new Node();
+
+    public EmojiTrie(Collection<Emoji> emojis) {
+        for(Emoji emoji: emojis) {
+            Node tree = root;
+            for (char c: emoji.getUnicode().toCharArray()) {
+                if (!tree.hasChild(c)) {
+                    tree.addChild(c);
+                }
+                tree = tree.getChild(c);
+            }
+            tree.setEmoji(emoji);
+        }
+    }
+
+
+    /**
+     * Checks if sequence of chars contain an emoji.
+     * @param emojiSequence Sequence of char that may contain emoji in full or partially.
+     * @return Returns
+     * Matches.EXACTLY if char sequence in its entirety is an emoji
+     * Matches.POSSIBLY if char sequence matches prefix of an emoji
+     * Matches.IMPOSSIBLE if char sequence matches no emoji or prefix of an emoji
+     */
+    public Matches isEmoji(char[] emojiSequence) {
+        Node tree = root;
+        for(char c: emojiSequence) {
+            if(! tree.hasChild(c)) {
+                return Matches.IMPOSSIBLE;
+            }
+            tree = tree.getChild(c);
+        }
+
+        return tree.isEndOfEmoji() ? Matches.EXACTLY : Matches.POSSIBLY;
+    }
+
+
+    /**
+     * Finds Emoji instance from emoji unicode
+     * @param unicode unicode of emoji to get
+     * @return Emoji instance if unicode matches and emoji, null otherwise.
+     */
+    public Emoji getEmoji(String unicode) {
+        Node tree = root;
+        for(char c: unicode.toCharArray()) {
+            if(! tree.hasChild(c)) {
+                return null;
+            }
+            tree = tree.getChild(c);
+        }
+        return tree.getEmoji();
+    }
+
+    enum Matches {
+        EXACTLY, POSSIBLY, IMPOSSIBLE;
+
+        public boolean exactMatch() {
+            return this == EXACTLY;
+        }
+
+        public boolean impossibleMatch() {
+            return this == IMPOSSIBLE;
+        }
+    }
+
+    private class Node {
+        private Map<Character, Node> children = new HashMap<Character, Node>();
+        private Emoji emoji;
+
+        private void setEmoji(Emoji emoji) {
+            this.emoji = emoji;
+        }
+
+        private Emoji getEmoji() {
+            return emoji;
+        }
+
+        private boolean hasChild(char child) {
+            return children.containsKey(child);
+        }
+
+        private void addChild(char child) {
+            children.put(child, new Node());
+        }
+
+        private Node getChild(char child) {
+            return children.get(child);
+        }
+
+        private boolean isEndOfEmoji() {
+            return emoji != null;
+        }
+    }
+}

--- a/src/main/java/com/vdurmont/emoji/Fitzpatrick.java
+++ b/src/main/java/com/vdurmont/emoji/Fitzpatrick.java
@@ -37,4 +37,22 @@ public enum Fitzpatrick {
     Fitzpatrick(String unicode) {
         this.unicode = unicode;
     }
+
+
+    public static Fitzpatrick fitzpatrickFromUnicode(String unicode) {
+        for(Fitzpatrick v : values()) {
+            if (v.unicode.equals(unicode)) {
+                return v;
+            }
+        }
+        return null;
+    }
+
+    public static Fitzpatrick fitzpatrickFromType(String type) {
+        try {
+            return Fitzpatrick.valueOf(type.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
 }


### PR DESCRIPTION
All of the function that replace from unicode to something else are extremely slow, especially for repeated calls, there are two main problems

1. Requires to iterate over all emojis
2. For each emoji it performs at least one `String.replace()` (2 if `FitzpatrickAction `is `Parse`) and a `String.replace()` creates a `Pattern `instance, which means for repeated calls, we will be making the same Pattern instances over and over.

I fixed both problems by storing the emoji unicode in a trie data structure where each char is a level in the tree. This way, I can replace all/or some emojis in a single traversal over the input string. I applied this fix to `parseToAliases()`, `parseToHtmlDecimal()`, `parseToHtmlHexadecimal()`, `removeAllEmojis()`, `removeEmojis()` and `removeAllEmojisExcept()`.

I ran a similar test to what you posted in #5 on 10 000 random tweets:
```java
long sumOld = 0;
long sumNew = 0;

Scanner scanner = new Scanner(new File(path));
while (scanner.hasNext()) {
    String input = scanner.nextLine();

    long t0 = System.currentTimeMillis();

    String parsed0 = EmojiParser.parseToAliases(input);
    String parsed1 = EmojiParser.parseToHtmlDecimal(input);
    String parsed2 = EmojiParser.parseToHtmlHexadecimal(input);
    String parsed4 = EmojiParser.removeAllEmojis(input);

    long t1 = System.currentTimeMillis();

    parsed0 = EmojiParserOld.parseToAliases(input);
    parsed1 = EmojiParserOld.parseToHtmlDecimal(input);
    parsed2 = EmojiParserOld.parseToHtmlHexadecimal(input);
    parsed4 = EmojiParserOld.removeAllEmojis(input);

    long t2 = System.currentTimeMillis();

    sumNew += (t1 - t0);
    sumOld += (t2 - t1);
}


System.out.println("Took " + sumNew + "ms with the new method against " + sumOld + "ms with the old method");
```


My end result is:
Took 308ms with the new method against 39001ms with the old method

EDIT:
I forgot to mention that this also fixes overlapping matching: 
```java
String familyManWomanBoy = "\uD83D\uDC68\u200D\uD83D\uDC69\u200D\uD83D\uDC66";
System.out.println(EmojiParser.parseToAliases(familyManWomanBoy));
```

With the current EmojiParser will return `:man::woman::boy:` while the correct(?) return should be `:family_man_woman_boy:` which is exactly what this EmojiParser will return.