### PR TITLE
refactorings + backwards-compatible arbitrary emoji processing API

### DIFF
--- a/src/main/java/com/vdurmont/emoji/Emoji.java
+++ b/src/main/java/com/vdurmont/emoji/Emoji.java
@@ -147,8 +147,15 @@ public class Emoji {
      *
      * @return the HTML hexadecimal representation
      */
-    public String getHtmlHexidecimal() {
+    public String getHtmlHexadecimal() {
         return this.htmlHex;
+    }
+
+    /**
+     * @deprecated identical to {@link #getHtmlHexadecimal()} for backwards-compatibility. use that instead.
+     */
+    public String getHtmlHexidecimal() {
+        return getHtmlHexadecimal();
     }
 
     @Override

--- a/src/main/java/com/vdurmont/emoji/parsers/AliasCandidate.java
+++ b/src/main/java/com/vdurmont/emoji/parsers/AliasCandidate.java
@@ -1,0 +1,22 @@
+package com.vdurmont.emoji.parsers;
+
+import com.vdurmont.emoji.Fitzpatrick;
+
+/**
+ * A POJO which represents a string of text identified as potentially an ASCII alias for an emoji.
+ */
+public class AliasCandidate {
+    public final String fullString;
+    public final String alias;
+    public final Fitzpatrick fitzpatrick;
+
+    public AliasCandidate(String fullString, String alias, String fitzpatrickString) {
+        this.fullString = fullString;
+        this.alias = alias;
+        if (fitzpatrickString == null) {
+            this.fitzpatrick = null;
+        } else {
+            this.fitzpatrick = Fitzpatrick.fitzpatrickFromType(fitzpatrickString);
+        }
+    }
+}

--- a/src/main/java/com/vdurmont/emoji/parsers/AliasProcessor.java
+++ b/src/main/java/com/vdurmont/emoji/parsers/AliasProcessor.java
@@ -1,0 +1,17 @@
+package com.vdurmont.emoji.parsers;
+
+import com.vdurmont.emoji.Emoji;
+
+/**
+ * Defines a type which can perform string substitutions on detected emoji aliases.
+ */
+public interface AliasProcessor {
+    /**
+     * A function that takes an {@link AliasCandidate} as extracted from <code>:<b>an_alias</b><i>|optional_fitzpatrick</i>:</code>
+     * and returns what to replace it with. The colons get removed as well.
+     * @param alias The string which was identified as potentially being an emoji alias.
+     * @param emoji The {@link Emoji} that <code>alias</code> is associated with, or <code>null</code> if it's not associated
+     * @return the string you want to replace <code>:alias:</code> with, or null to leave it unchanged
+     */
+    String apply(AliasCandidate alias, Emoji emoji);
+}

--- a/src/main/java/com/vdurmont/emoji/parsers/AliasProcessors.java
+++ b/src/main/java/com/vdurmont/emoji/parsers/AliasProcessors.java
@@ -1,0 +1,32 @@
+package com.vdurmont.emoji.parsers;
+
+import com.vdurmont.emoji.Emoji;
+
+/**
+ * Contains built-in AliasProcessors.
+ */
+public class AliasProcessors {
+    /**
+     * Singleton class.
+     */
+    private AliasProcessors() { }
+
+    /**
+     * Provides the alias processing implementation for {@link com.vdurmont.emoji.EmojiParser#parseToUnicode(String)}
+     */
+    public static final AliasProcessor TO_UNICODE = new AliasProcessor() {
+        @Override
+        public String apply(AliasCandidate alias, Emoji emoji) {
+            if (emoji != null) {
+                boolean aliasHasFitzpatrick = alias.fitzpatrick != null;
+                if(!emoji.supportsFitzpatrick() && aliasHasFitzpatrick) {
+                    return null;
+                } else {
+                    return emoji.getUnicode() + (aliasHasFitzpatrick ? alias.fitzpatrick.unicode : "");
+                }
+            }
+
+            return null;
+        }
+    };
+}

--- a/src/main/java/com/vdurmont/emoji/parsers/UnicodeCandidate.java
+++ b/src/main/java/com/vdurmont/emoji/parsers/UnicodeCandidate.java
@@ -1,0 +1,35 @@
+package com.vdurmont.emoji.parsers;
+
+import com.vdurmont.emoji.Emoji;
+import com.vdurmont.emoji.EmojiManager;
+import com.vdurmont.emoji.Fitzpatrick;
+
+/**
+ * A detected emoji with associated metadata.
+ */
+public class UnicodeCandidate {
+    public final Emoji emoji;
+    public final Fitzpatrick fitzpatrick;
+    public final int startIndex, endIndex;
+
+    public UnicodeCandidate(String emoji, String fitzpatrick, int startIndex, int endIndex) {
+        this.emoji = EmojiManager.getByUnicode(emoji);
+        this.fitzpatrick = Fitzpatrick.fitzpatrickFromUnicode(fitzpatrick);
+        this.startIndex = startIndex;
+        this.endIndex = endIndex;
+    }
+
+    public String getEmojiUnicodeWithFitzpatrick() {
+        if(emoji.supportsFitzpatrick()) return emoji.getUnicode(fitzpatrick);
+        return emoji.getUnicode();
+    }
+
+    public int getEndIndexWithFitzpatrick() {
+        if(hasFitzpatrick()) return endIndex+2;
+        return endIndex;
+    }
+
+    public boolean hasFitzpatrick() {
+        return fitzpatrick != null;
+    }
+}

--- a/src/main/java/com/vdurmont/emoji/parsers/UnicodeProcessor.java
+++ b/src/main/java/com/vdurmont/emoji/parsers/UnicodeProcessor.java
@@ -1,0 +1,24 @@
+package com.vdurmont.emoji.parsers;
+
+import com.vdurmont.emoji.EmojiParser.FitzpatrickAction;
+
+/**
+ * Defines a type which can perform string substitutions on detected unicode emoji.
+ */
+public interface UnicodeProcessor {
+    /**
+     * A function which takes an emoji identified in the corpus and replaces it with whatever.
+     * @param input the identified emoji
+     * @param fitzpatrickAction the {@link FitzpatrickAction} that the caller requested.
+     * @return a String with which to replace the identified emoji with.
+     */
+    String apply(UnicodeCandidate input, FitzpatrickAction fitzpatrickAction);
+
+    /**
+     * Whether or not to remove all Fitzpatrick modifiers from the corpus before
+     * processing with this UnicodeProcessor
+     * @param fitzpatrickAction the {@link FitzpatrickAction} that the caller requested.
+     * @return whether or not to strip all Fitzpatrick modifiers before processing the corpus.
+     */
+    boolean shouldRemoveFitzpatrick(FitzpatrickAction fitzpatrickAction);
+}

--- a/src/main/java/com/vdurmont/emoji/parsers/UnicodeProcessors.java
+++ b/src/main/java/com/vdurmont/emoji/parsers/UnicodeProcessors.java
@@ -1,0 +1,141 @@
+package com.vdurmont.emoji.parsers;
+
+import com.vdurmont.emoji.Emoji;
+import com.vdurmont.emoji.EmojiParser.FitzpatrickAction;
+
+import java.util.Collection;
+
+/**
+ * Contains built-in UnicodeProcessors.
+ */
+public class UnicodeProcessors {
+    /**
+     * Singleton class
+     */
+    private UnicodeProcessors() { }
+
+    /**
+     * Provides the implementation for {@link com.vdurmont.emoji.EmojiParser#removeAllEmojis(String)}
+     */
+    public static final UnicodeProcessor REMOVE_ALL_EMOJI = new UnicodeProcessor() {
+        @Override
+        public String apply(UnicodeCandidate input, FitzpatrickAction fitzpatrickAction) {
+            return "";
+        }
+
+        @Override
+        public boolean shouldRemoveFitzpatrick(FitzpatrickAction fitzpatrickAction) {
+            return true;
+        }
+    };
+
+    /**
+     * Generates an implementation for {@link com.vdurmont.emoji.EmojiParser#removeAllEmojisExcept(String, Collection)}
+     * @param emojisToKeep which emoji to NOT filter out
+     * @return a UnicodeProcessor that removes all emoji except those specified in <code>emojisToKeep</code>
+     */
+    public static UnicodeProcessor removeAllExcept(final Collection<Emoji> emojisToKeep) {
+        return new UnicodeProcessor() {
+            @Override
+            public String apply(UnicodeCandidate input, FitzpatrickAction fitzpatrickAction) {
+                return emojisToKeep.contains(input.emoji) ? input.getEmojiUnicodeWithFitzpatrick() : "";
+            }
+
+            @Override
+            public boolean shouldRemoveFitzpatrick(FitzpatrickAction fitzpatrickAction) {
+                return false;
+            }
+        };
+    }
+
+    /**
+     * Generates an implementation for {@link com.vdurmont.emoji.EmojiParser#removeEmojis(String, Collection)}
+     * @param emojisToRemove which emoji to filter out
+     * @return a UnicodeProcessor that removes all emoji except those specified in <code>emojisToRemove</code>
+     */
+    public static UnicodeProcessor removeOnly(final Collection<Emoji> emojisToRemove) {
+        return new UnicodeProcessor() {
+            @Override
+            public String apply(UnicodeCandidate input, FitzpatrickAction fitzpatrickAction) {
+                return emojisToRemove.contains(input.emoji) ? "" : input.getEmojiUnicodeWithFitzpatrick();
+            }
+
+            @Override
+            public boolean shouldRemoveFitzpatrick(FitzpatrickAction fitzpatrickAction) {
+                return false;
+            }
+        };
+    }
+
+    /**
+     * Provides the implementations of {@link com.vdurmont.emoji.EmojiParser#parseToAliases(String)} and
+     * {@link com.vdurmont.emoji.EmojiParser#parseToAliases(String, FitzpatrickAction)}
+     */
+    public static final UnicodeProcessor TO_ALIAS = new UnicodeProcessor() {
+        @Override
+        public String apply(UnicodeCandidate input, FitzpatrickAction fitzpatrickAction) {
+            String inputFitzpatrick = input.hasFitzpatrick() ? input.fitzpatrick.unicode : "";
+            String alias            = input.emoji.getAliases().get(0);
+
+            if(fitzpatrickAction == FitzpatrickAction.PARSE && input.emoji.supportsFitzpatrick()) {
+                if (input.hasFitzpatrick()) {
+                    return String.format(
+                            ":%s|%s:",
+                            alias,
+                            input.fitzpatrick.name().toLowerCase());
+                }
+            }
+
+            if(fitzpatrickAction == FitzpatrickAction.IGNORE) {
+                return String.format(":%s:%s", alias, inputFitzpatrick);
+            } else {
+                return ":" + alias + ":";
+            }
+        }
+
+        @Override
+        public boolean shouldRemoveFitzpatrick(FitzpatrickAction fitzpatrickAction) {
+            return fitzpatrickAction == FitzpatrickAction.REMOVE;
+        }
+    };
+
+    /**
+     * Provides the implementations of {@link com.vdurmont.emoji.EmojiParser#parseToHtmlHexadecimal(String)} and
+     * {@link com.vdurmont.emoji.EmojiParser#parseToHtmlHexadecimal(String, FitzpatrickAction)}
+     */
+    public static final UnicodeProcessor TO_HTML_HEX = new UnicodeProcessor() {
+        @Override
+        public String apply(UnicodeCandidate input, FitzpatrickAction fitzpatrickAction) {
+            String hex = input.emoji.getHtmlHexadecimal();
+            if(fitzpatrickAction == FitzpatrickAction.IGNORE && input.fitzpatrick != null) {
+                return hex + input.fitzpatrick.unicode;
+            }
+            return hex;
+        }
+
+        @Override
+        public boolean shouldRemoveFitzpatrick(FitzpatrickAction fitzpatrickAction) {
+            return fitzpatrickAction != FitzpatrickAction.IGNORE;
+        }
+    };
+
+    /**
+     * Provides the implementations of {@link com.vdurmont.emoji.EmojiParser#parseToHtmlDecimal(String)} and
+     * {@link com.vdurmont.emoji.EmojiParser#parseToHtmlDecimal(String, FitzpatrickAction)}
+     */
+    public static final UnicodeProcessor TO_HTML_DEC = new UnicodeProcessor() {
+        @Override
+        public String apply(UnicodeCandidate input, FitzpatrickAction fitzpatrickAction) {
+            String dec = input.emoji.getHtmlDecimal();
+            if(fitzpatrickAction == FitzpatrickAction.IGNORE && input.fitzpatrick != null) {
+                return dec + input.fitzpatrick.unicode;
+            }
+            return dec;
+        }
+
+        @Override
+        public boolean shouldRemoveFitzpatrick(FitzpatrickAction fitzpatrickAction) {
+            return fitzpatrickAction != FitzpatrickAction.IGNORE;
+        }
+    };
+}

--- a/src/test/java/com/vdurmont/emoji/EmojiParserTest.java
+++ b/src/test/java/com/vdurmont/emoji/EmojiParserTest.java
@@ -1,6 +1,6 @@
 package com.vdurmont.emoji;
 
-import com.vdurmont.emoji.EmojiParser.AliasCandidate;
+import com.vdurmont.emoji.parsers.AliasCandidate;
 import com.vdurmont.emoji.EmojiParser.FitzpatrickAction;
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
Hello!

Thanks for writing this library, it's definitely saved me a bit of manual labor! I've made some changes, and hopefully you and others might find them handy.

This PR:
* Typo fix: rename `Emoji::getHtmlHex`**i**`decimal` to `Emoji::getHtmlHex`**a**`decimal`, but leaves in the old one with a deprecation warning. Hex**a**decimal is used everywhere else in the code.
* Creates interfaces `UnicodeProcessor` and `AliasProcessor`, which are used by `EmojiParser::processUnicode` and `EmojiParser::processAliases`. These two new methods are generalizations of `EmojiParser::parseTo***`
* Converts the existing `EmojiParser::parseTo***` to use the new `EmojiParser::process***` API. These conversions are placed in `UnicodeParsers` and `AliasParsers`, both singleton classes.
* Extracts `AliasCandidate` and `UnicodeCandidate` to public classes, instead of inner protected classes of `EmojiParser` as the processor types depend on these.

In the case of AliasParser, I avoided using Java 8 functional interfaces to allow full backwards-compatibility with Java <8. 

Tests are green across the board, and these changes won't (or at least *shouldn't*) break any existing code that uses this library. If you'd like, I can also add a blurb to the README describing the new processing API.