### PR TITLE
Custom replacement of unicode emojis

### DIFF
--- a/src/main/java/com/vdurmont/emoji/EmojiTrie.java
+++ b/src/main/java/com/vdurmont/emoji/EmojiTrie.java
@@ -62,7 +62,7 @@ public class EmojiTrie {
         return tree.getEmoji();
     }
 
-    enum Matches {
+    public enum Matches {
         EXACTLY, POSSIBLY, IMPOSSIBLE;
 
         public boolean exactMatch() {

--- a/src/test/java/com/vdurmont/emoji/EmojiParserTest.java
+++ b/src/test/java/com/vdurmont/emoji/EmojiParserTest.java
@@ -87,6 +87,31 @@ public class EmojiParserTest {
     }
 
     @Test
+    public void parseToAliases_with_long_overlapping_emoji() {
+        // GIVEN
+        String str = "\uD83D\uDC68\u200D\uD83D\uDC69\u200D\uD83D\uDC66";
+
+        // WHEN
+        String result = EmojiParser.parseToAliases(str);
+
+        //With greedy parsing, this will give :man::woman::boy:
+        //THEN
+        assertEquals(":family_man_woman_boy:", result);
+    }
+
+    @Test
+    public void parseToAliases_continuous_non_overlapping_emojis() {
+        // GIVEN
+        String str = "\uD83D\uDC69\uD83D\uDC68\uD83D\uDC66";
+
+        // WHEN
+        String result = EmojiParser.parseToAliases(str);
+
+        //THEN
+        assertEquals(":woman::man::boy:", result);
+    }
+
+    @Test
     public void parseToHtmlDecimal_replaces_the_emojis_by_their_html_decimal_representation() {
         // GIVEN
         String str = "An 😀awesome 😃string with a few 😉emojis!";


### PR DESCRIPTION
These changes makes it possible to easily add own custom replacement for unicode emojis as I've described in #27, I'm not sure if you are interested since I haven't heard back on that, but I thought I'd submit the code here in case you wanna try it. To test the generality of the new interface, I re-implemented all the from-unicode functions to use this interface (`parseToAliases()`, `parseToHtmlDecimal()`, `parseToHtmlHexadecimal()`, `removeAllEmojis()`, `removeEmojis()` and `removeAllEmojisExcept()`) and tested on against 3.1 release on 100, 10k, 1m, and 82.5m calls, and on each there was about 2x speed improvement which at first was somewhat surprising, but I guess this is because I was able to get rid of the regex replacement for the fitzpatrick modifiers. 

All in all, this keeps all of the existing functions adding only 1 extra, makes the code much easier to read and provides a 2x speed improvement over current release.