### PR TITLE
Add support for Slack emojis

### DIFF
--- a/src/main/resources/emojis.json
+++ b/src/main/resources/emojis.json
@@ -1,12686 +1,12910 @@
 [
   {
-    "emoji": "😄",
-    "description": "smiling face with open mouth and smiling eyes",
     "aliases": [
-      "smile"
+      "older_woman"
     ],
-    "tags": [
-      "happy",
-      "joy",
-      "pleased"
-    ]
+    "supports_fitzpatrick": true,
+    "description": "older woman",
+    "tags": [],
+    "emoji": "👵"
   },
   {
-    "emoji": "😃",
-    "description": "smiling face with open mouth",
     "aliases": [
-      "smiley"
+      "older_man"
     ],
-    "tags": [
-      "happy",
-      "joy",
-      "haha"
-    ]
+    "supports_fitzpatrick": true,
+    "description": "older man",
+    "tags": [],
+    "emoji": "👴"
   },
   {
-    "emoji": "😀",
-    "description": "grinning face",
     "aliases": [
-      "grinning"
+      "construction_worker"
     ],
+    "supports_fitzpatrick": true,
+    "description": "construction worker",
     "tags": [
-      "smile",
-      "happy"
-    ]
+      "helmet"
+    ],
+    "emoji": "👷"
   },
   {
-    "emoji": "😊",
-    "description": "smiling face with smiling eyes",
     "aliases": [
-      "blush"
+      "baby"
     ],
+    "supports_fitzpatrick": true,
+    "description": "baby",
     "tags": [
-      "proud"
-    ]
+      "child",
+      "newborn"
+    ],
+    "emoji": "👶"
   },
   {
-    "emoji": "☺",
-    "description": "white smiling face",
     "aliases": [
-      "relaxed"
+      "person_with_blond_hair"
     ],
+    "supports_fitzpatrick": true,
+    "description": "person with blond hair",
     "tags": [
-      "blush",
-      "pleased"
-    ]
+      "boy"
+    ],
+    "emoji": "👱"
   },
   {
-    "emoji": "😉",
-    "description": "winking face",
     "aliases": [
-      "wink"
+      "bride_with_veil"
     ],
+    "supports_fitzpatrick": true,
+    "description": "bride with veil",
     "tags": [
-      "flirt"
-    ]
+      "marriage",
+      "wedding"
+    ],
+    "emoji": "👰"
   },
   {
-    "emoji": "😍",
-    "description": "smiling face with heart-shaped eyes",
     "aliases": [
-      "heart_eyes"
+      "man_with_turban"
     ],
-    "tags": [
-      "love",
-      "crush"
-    ]
+    "supports_fitzpatrick": true,
+    "description": "man with turban",
+    "tags": [],
+    "emoji": "👳"
   },
   {
-    "emoji": "😘",
-    "description": "face throwing a kiss",
     "aliases": [
-      "kissing_heart"
+      "man_with_gua_pi_mao"
     ],
-    "tags": [
-      "flirt"
-    ]
+    "supports_fitzpatrick": true,
+    "description": "man with gua pi mao",
+    "tags": [],
+    "emoji": "👲"
   },
   {
-    "emoji": "😚",
-    "description": "kissing face with closed eyes",
     "aliases": [
-      "kissing_closed_eyes"
+      "alien"
     ],
+    "description": "extraterrestrial alien",
     "tags": [
-    ]
+      "ufo"
+    ],
+    "emoji": "👽"
   },
   {
-    "emoji": "😗",
-    "description": "kissing face",
     "aliases": [
-      "kissing"
+      "angel"
     ],
-    "tags": [
-    ]
+    "supports_fitzpatrick": true,
+    "description": "baby angel",
+    "tags": [],
+    "emoji": "👼"
   },
   {
-    "emoji": "😙",
-    "description": "kissing face with smiling eyes",
-    "aliases": [
-      "kissing_smiling_eyes"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "😜",
-    "description": "face with stuck-out tongue and winking eye",
-    "aliases": [
-      "stuck_out_tongue_winking_eye"
-    ],
-    "tags": [
-      "prank",
-      "silly"
-    ]
-  },
-  {
-    "emoji": "😝",
-    "description": "face with stuck-out tongue and tightly-closed eyes",
-    "aliases": [
-      "stuck_out_tongue_closed_eyes"
-    ],
-    "tags": [
-      "prank"
-    ]
-  },
-  {
-    "emoji": "😛",
-    "description": "face with stuck-out tongue",
-    "aliases": [
-      "stuck_out_tongue"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "😳",
-    "description": "flushed face",
-    "aliases": [
-      "flushed"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "😁",
-    "description": "grinning face with smiling eyes",
-    "aliases": [
-      "grin"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "😔",
-    "description": "pensive face",
-    "aliases": [
-      "pensive"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "😌",
-    "description": "relieved face",
-    "aliases": [
-      "relieved"
-    ],
-    "tags": [
-      "whew"
-    ]
-  },
-  {
-    "emoji": "😒",
-    "description": "unamused face",
-    "aliases": [
-      "unamused"
-    ],
-    "tags": [
-      "meh"
-    ]
-  },
-  {
-    "emoji": "😞",
-    "description": "disappointed face",
-    "aliases": [
-      "disappointed"
-    ],
-    "tags": [
-      "sad"
-    ]
-  },
-  {
-    "emoji": "😣",
-    "description": "persevering face",
-    "aliases": [
-      "persevere"
-    ],
-    "tags": [
-      "struggling"
-    ]
-  },
-  {
-    "emoji": "😢",
-    "description": "crying face",
-    "aliases": [
-      "cry"
-    ],
-    "tags": [
-      "sad",
-      "tear"
-    ]
-  },
-  {
-    "emoji": "😂",
-    "description": "face with tears of joy",
-    "aliases": [
-      "joy"
-    ],
-    "tags": [
-      "tears"
-    ]
-  },
-  {
-    "emoji": "😭",
-    "description": "loudly crying face",
-    "aliases": [
-      "sob"
-    ],
-    "tags": [
-      "sad",
-      "cry",
-      "bawling"
-    ]
-  },
-  {
-    "emoji": "😪",
-    "description": "sleepy face",
-    "aliases": [
-      "sleepy"
-    ],
-    "tags": [
-      "tired"
-    ]
-  },
-  {
-    "emoji": "😥",
-    "description": "disappointed but relieved face",
-    "aliases": [
-      "disappointed_relieved"
-    ],
-    "tags": [
-      "phew",
-      "sweat",
-      "nervous"
-    ]
-  },
-  {
-    "emoji": "😰",
-    "description": "face with open mouth and cold sweat",
-    "aliases": [
-      "cold_sweat"
-    ],
-    "tags": [
-      "nervous"
-    ]
-  },
-  {
-    "emoji": "😅",
-    "description": "smiling face with open mouth and cold sweat",
-    "aliases": [
-      "sweat_smile"
-    ],
-    "tags": [
-      "hot"
-    ]
-  },
-  {
-    "emoji": "😓",
-    "description": "face with cold sweat",
-    "aliases": [
-      "sweat"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "😩",
-    "description": "weary face",
-    "aliases": [
-      "weary"
-    ],
-    "tags": [
-      "tired"
-    ]
-  },
-  {
-    "emoji": "😫",
-    "description": "tired face",
-    "aliases": [
-      "tired_face"
-    ],
-    "tags": [
-      "upset",
-      "whine"
-    ]
-  },
-  {
-    "emoji": "😨",
-    "description": "fearful face",
-    "aliases": [
-      "fearful"
-    ],
-    "tags": [
-      "scared",
-      "shocked",
-      "oops"
-    ]
-  },
-  {
-    "emoji": "😱",
-    "description": "face screaming in fear",
-    "aliases": [
-      "scream"
-    ],
-    "tags": [
-      "horror",
-      "shocked"
-    ]
-  },
-  {
-    "emoji": "😠",
-    "description": "angry face",
-    "aliases": [
-      "angry"
-    ],
-    "tags": [
-      "mad",
-      "annoyed"
-    ]
-  },
-  {
-    "emoji": "😡",
-    "description": "pouting face",
-    "aliases": [
-      "rage"
-    ],
-    "tags": [
-      "angry"
-    ]
-  },
-  {
-    "emoji": "😤",
-    "description": "face with look of triumph",
-    "aliases": [
-      "triumph"
-    ],
-    "tags": [
-      "smug"
-    ]
-  },
-  {
-    "emoji": "😖",
-    "description": "confounded face",
-    "aliases": [
-      "confounded"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "😆",
-    "description": "smiling face with open mouth and tightly-closed eyes",
-    "aliases": [
-      "laughing",
-      "satisfied"
-    ],
-    "tags": [
-      "happy",
-      "haha"
-    ]
-  },
-  {
-    "emoji": "😋",
-    "description": "face savouring delicious food",
-    "aliases": [
-      "yum"
-    ],
-    "tags": [
-      "tongue",
-      "lick"
-    ]
-  },
-  {
-    "emoji": "😷",
-    "description": "face with medical mask",
-    "aliases": [
-      "mask"
-    ],
-    "tags": [
-      "sick",
-      "ill"
-    ]
-  },
-  {
-    "emoji": "😎",
-    "description": "smiling face with sunglasses",
-    "aliases": [
-      "sunglasses"
-    ],
-    "tags": [
-      "cool"
-    ]
-  },
-  {
-    "emoji": "😴",
-    "description": "sleeping face",
-    "aliases": [
-      "sleeping"
-    ],
-    "tags": [
-      "zzz"
-    ]
-  },
-  {
-    "emoji": "😵",
-    "description": "dizzy face",
-    "aliases": [
-      "dizzy_face"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "😲",
-    "description": "astonished face",
-    "aliases": [
-      "astonished"
-    ],
-    "tags": [
-      "amazed",
-      "gasp"
-    ]
-  },
-  {
-    "emoji": "😟",
-    "description": "worried face",
-    "aliases": [
-      "worried"
-    ],
-    "tags": [
-      "nervous"
-    ]
-  },
-  {
-    "emoji": "😦",
-    "description": "frowning face with open mouth",
-    "aliases": [
-      "frowning"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "😧",
-    "description": "anguished face",
-    "aliases": [
-      "anguished"
-    ],
-    "tags": [
-      "stunned"
-    ]
-  },
-  {
-    "emoji": "😈",
-    "description": "smiling face with horns",
-    "aliases": [
-      "smiling_imp"
-    ],
-    "tags": [
-      "devil",
-      "evil",
-      "horns"
-    ]
-  },
-  {
-    "emoji": "👿",
-    "description": "imp",
     "aliases": [
       "imp"
     ],
+    "description": "imp",
     "tags": [
       "angry",
       "devil",
       "evil",
       "horns"
-    ]
-  },
-  {
-    "emoji": "😮",
-    "description": "face with open mouth",
-    "aliases": [
-      "open_mouth"
     ],
-    "tags": [
-      "surprise",
-      "impressed",
-      "wow"
-    ]
+    "emoji": "👿"
   },
   {
-    "emoji": "😬",
-    "description": "grimacing face",
     "aliases": [
-      "grimacing"
+      "fist"
     ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "😐",
-    "description": "neutral face",
-    "aliases": [
-      "neutral_face"
-    ],
-    "tags": [
-      "meh"
-    ]
-  },
-  {
-    "emoji": "😕",
-    "description": "confused face",
-    "aliases": [
-      "confused"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "😯",
-    "description": "hushed face",
-    "aliases": [
-      "hushed"
-    ],
-    "tags": [
-      "silence",
-      "speechless"
-    ]
-  },
-  {
-    "emoji": "😶",
-    "description": "face without mouth",
-    "aliases": [
-      "no_mouth"
-    ],
-    "tags": [
-      "mute",
-      "silence"
-    ]
-  },
-  {
-    "emoji": "😇",
-    "description": "smiling face with halo",
-    "aliases": [
-      "innocent"
-    ],
-    "tags": [
-      "angel"
-    ]
-  },
-  {
-    "emoji": "😏",
-    "description": "smirking face",
-    "aliases": [
-      "smirk"
-    ],
-    "tags": [
-      "smug"
-    ]
-  },
-  {
-    "emoji": "😑",
-    "description": "expressionless face",
-    "aliases": [
-      "expressionless"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "👲",
-    "description": "man with gua pi mao",
     "supports_fitzpatrick": true,
-    "aliases": [
-      "man_with_gua_pi_mao"
-    ],
+    "description": "raised fist",
     "tags": [
-    ]
+      "power"
+    ],
+    "emoji": "✊"
   },
   {
-    "emoji": "👳",
-    "description": "man with turban",
-    "supports_fitzpatrick": true,
     "aliases": [
-      "man_with_turban"
+      "japanese_ogre"
     ],
+    "description": "japanese ogre",
     "tags": [
-    ]
+      "monster"
+    ],
+    "emoji": "👹"
   },
   {
-    "emoji": "👮",
-    "description": "police officer",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "cop"
-    ],
-    "tags": [
-      "police",
-      "law"
-    ]
-  },
-  {
-    "emoji": "👷",
-    "description": "construction worker",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "construction_worker"
-    ],
-    "tags": [
-      "helmet"
-    ]
-  },
-  {
-    "emoji": "💂",
-    "description": "guardsman",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "guardsman"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "👶",
-    "description": "baby",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "baby"
-    ],
-    "tags": [
-      "child",
-      "newborn"
-    ]
-  },
-  {
-    "emoji": "👦",
-    "description": "boy",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "boy"
-    ],
-    "tags": [
-      "child"
-    ]
-  },
-  {
-    "emoji": "👧",
-    "description": "girl",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "girl"
-    ],
-    "tags": [
-      "child"
-    ]
-  },
-  {
-    "emoji": "👨",
-    "description": "man",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "man"
-    ],
-    "tags": [
-      "mustache",
-      "father",
-      "dad"
-    ]
-  },
-  {
-    "emoji": "👩",
-    "description": "woman",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "woman"
-    ],
-    "tags": [
-      "girls"
-    ]
-  },
-  {
-    "emoji": "👴",
-    "description": "older man",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "older_man"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "👵",
-    "description": "older woman",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "older_woman"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "👱",
-    "description": "person with blond hair",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "person_with_blond_hair"
-    ],
-    "tags": [
-      "boy"
-    ]
-  },
-  {
-    "emoji": "👼",
-    "description": "baby angel",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "angel"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "👸",
-    "description": "princess",
-    "supports_fitzpatrick": true,
     "aliases": [
       "princess"
     ],
+    "supports_fitzpatrick": true,
+    "description": "princess",
     "tags": [
       "blonde",
       "crown",
       "royal"
-    ]
-  },
-  {
-    "emoji": "😺",
-    "description": "smiling cat face with open mouth",
-    "aliases": [
-      "smiley_cat"
     ],
-    "tags": [
-    ]
+    "emoji": "👸"
   },
   {
-    "emoji": "😸",
-    "description": "grinning cat face with smiling eyes",
     "aliases": [
-      "smile_cat"
+      "ghost"
     ],
+    "description": "ghost",
     "tags": [
-    ]
+      "halloween"
+    ],
+    "emoji": "👻"
   },
   {
-    "emoji": "😻",
-    "description": "smiling cat face with heart-shaped eyes",
-    "aliases": [
-      "heart_eyes_cat"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "😽",
-    "description": "kissing cat face with closed eyes",
-    "aliases": [
-      "kissing_cat"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "😼",
-    "description": "cat face with wry smile",
-    "aliases": [
-      "smirk_cat"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🙀",
-    "description": "weary cat face",
-    "aliases": [
-      "scream_cat"
-    ],
-    "tags": [
-      "horror"
-    ]
-  },
-  {
-    "emoji": "😿",
-    "description": "crying cat face",
-    "aliases": [
-      "crying_cat_face"
-    ],
-    "tags": [
-      "sad",
-      "tear"
-    ]
-  },
-  {
-    "emoji": "😹",
-    "description": "cat face with tears of joy",
-    "aliases": [
-      "joy_cat"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "😾",
-    "description": "pouting cat face",
-    "aliases": [
-      "pouting_cat"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "👹",
-    "description": "japanese ogre",
-    "aliases": [
-      "japanese_ogre"
-    ],
-    "tags": [
-      "monster"
-    ]
-  },
-  {
-    "emoji": "👺",
-    "description": "japanese goblin",
     "aliases": [
       "japanese_goblin"
     ],
-    "tags": [
-    ]
+    "description": "japanese goblin",
+    "tags": [],
+    "emoji": "👺"
   },
   {
-    "emoji": "🙈",
-    "description": "see-no-evil monkey",
     "aliases": [
-      "see_no_evil"
+      "busts_in_silhouette"
     ],
+    "description": "busts in silhouette",
     "tags": [
-      "monkey",
-      "blind",
-      "ignore"
-    ]
+      "users",
+      "group",
+      "team"
+    ],
+    "emoji": "👥"
   },
   {
-    "emoji": "🙉",
-    "description": "hear-no-evil monkey",
     "aliases": [
-      "hear_no_evil"
+      "bust_in_silhouette"
     ],
+    "description": "bust in silhouette",
     "tags": [
-      "monkey",
-      "deaf"
-    ]
+      "user"
+    ],
+    "emoji": "👤"
   },
   {
-    "emoji": "🙊",
-    "description": "speak-no-evil monkey",
     "aliases": [
-      "speak_no_evil"
+      "girl"
     ],
-    "tags": [
-      "monkey",
-      "mute",
-      "hush"
-    ]
-  },
-  {
-    "emoji": "💀",
-    "description": "skull",
-    "aliases": [
-      "skull"
-    ],
-    "tags": [
-      "dead",
-      "danger",
-      "poison"
-    ]
-  },
-  {
-    "emoji": "👽",
-    "description": "extraterrestrial alien",
-    "aliases": [
-      "alien"
-    ],
-    "tags": [
-      "ufo"
-    ]
-  },
-  {
-    "emoji": "💩",
-    "description": "pile of poo",
-    "aliases": [
-      "hankey",
-      "poop",
-      "shit"
-    ],
-    "tags": [
-      "crap"
-    ]
-  },
-  {
-    "emoji": "🔥",
-    "description": "fire",
-    "aliases": [
-      "fire"
-    ],
-    "tags": [
-      "burn"
-    ]
-  },
-  {
-    "emoji": "✨",
-    "description": "sparkles",
-    "aliases": [
-      "sparkles"
-    ],
-    "tags": [
-      "shiny"
-    ]
-  },
-  {
-    "emoji": "🌟",
-    "description": "glowing star",
-    "aliases": [
-      "star2"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "💫",
-    "description": "dizzy symbol",
-    "aliases": [
-      "dizzy"
-    ],
-    "tags": [
-      "star"
-    ]
-  },
-  {
-    "emoji": "💥",
-    "description": "collision symbol",
-    "aliases": [
-      "boom",
-      "collision"
-    ],
-    "tags": [
-      "explode"
-    ]
-  },
-  {
-    "emoji": "💢",
-    "description": "anger symbol",
-    "aliases": [
-      "anger"
-    ],
-    "tags": [
-      "angry"
-    ]
-  },
-  {
-    "emoji": "💦",
-    "description": "splashing sweat symbol",
-    "aliases": [
-      "sweat_drops"
-    ],
-    "tags": [
-      "water",
-      "workout"
-    ]
-  },
-  {
-    "emoji": "💧",
-    "description": "droplet",
-    "aliases": [
-      "droplet"
-    ],
-    "tags": [
-      "water"
-    ]
-  },
-  {
-    "emoji": "💤",
-    "description": "sleeping symbol",
-    "aliases": [
-      "zzz"
-    ],
-    "tags": [
-      "sleeping"
-    ]
-  },
-  {
-    "emoji": "💨",
-    "description": "dash symbol",
-    "aliases": [
-      "dash"
-    ],
-    "tags": [
-      "wind",
-      "blow",
-      "fast"
-    ]
-  },
-  {
-    "emoji": "👂",
-    "description": "ear",
     "supports_fitzpatrick": true,
-    "aliases": [
-      "ear"
-    ],
+    "description": "girl",
     "tags": [
-      "hear",
-      "sound",
-      "listen"
+      "child"
+    ],
+    "emoji": "👧"
+  },
+  {
+    "aliases": [
+      "boy"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "boy",
+    "tags": [
+      "child"
+    ],
+    "emoji": "👦"
+  },
+  {
+    "aliases": [
+      "sandal"
+    ],
+    "description": "womans sandal",
+    "tags": [
+      "shoe"
+    ],
+    "emoji": "👡"
+  },
+  {
+    "aliases": [
+      "high_heel"
+    ],
+    "description": "high-heeled shoe",
+    "tags": [
+      "shoe"
+    ],
+    "emoji": "👠"
+  },
+  {
+    "aliases": [
+      "footprints"
+    ],
+    "description": "footprints",
+    "tags": [
+      "feet",
+      "tracks"
+    ],
+    "emoji": "👣"
+  },
+  {
+    "aliases": [
+      "boot"
+    ],
+    "description": "womans boots",
+    "tags": [],
+    "emoji": "👢"
+  },
+  {
+    "aliases": [
+      "two_women_holding_hands"
+    ],
+    "description": "two women holding hands",
+    "tags": [
+      "couple",
+      "date"
+    ],
+    "emoji": "👭"
+  },
+  {
+    "aliases": [
+      "two_men_holding_hands"
+    ],
+    "description": "two men holding hands",
+    "tags": [
+      "couple",
+      "date"
+    ],
+    "emoji": "👬"
+  },
+  {
+    "aliases": [
+      "dancers"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "woman with bunny ears",
+    "tags": [
+      "bunny"
+    ],
+    "emoji": "👯"
+  },
+  {
+    "aliases": [
+      "cop"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "police officer",
+    "tags": [
+      "police",
+      "law"
+    ],
+    "emoji": "👮"
+  },
+  {
+    "aliases": [
+      "woman"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "woman",
+    "tags": [
+      "girls"
+    ],
+    "emoji": "👩"
+  },
+  {
+    "aliases": [
+      "man"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "man",
+    "tags": [
+      "mustache",
+      "father",
+      "dad"
+    ],
+    "emoji": "👨"
+  },
+  {
+    "aliases": [
+      "couple",
+      "man_and_woman_holding_hands"
+    ],
+    "description": "man and woman holding hands",
+    "tags": [
+      "date"
+    ],
+    "emoji": "👫"
+  },
+  {
+    "aliases": [
+      "man-woman-boy",
+      "family"
+    ],
+    "description": "family",
+    "tags": [
+      "home",
+      "parents",
+      "child"
+    ],
+    "emoji": "👪"
+  },
+  {
+    "aliases": [
+      "tshirt",
+      "shirt"
+    ],
+    "description": "t-shirt",
+    "tags": [],
+    "emoji": "👕"
+  },
+  {
+    "aliases": [
+      "necktie"
+    ],
+    "description": "necktie",
+    "tags": [
+      "shirt",
+      "formal"
+    ],
+    "emoji": "👔"
+  },
+  {
+    "aliases": [
+      "dress"
+    ],
+    "description": "dress",
+    "tags": [],
+    "emoji": "👗"
+  },
+  {
+    "aliases": [
+      "jeans"
+    ],
+    "description": "jeans",
+    "tags": [
+      "pants"
+    ],
+    "emoji": "👖"
+  },
+  {
+    "aliases": [
+      "crown"
+    ],
+    "description": "crown",
+    "tags": [
+      "king",
+      "queen",
+      "royal"
+    ],
+    "emoji": "👑"
+  },
+  {
+    "aliases": [
+      "open_hands"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "open hands sign",
+    "tags": [],
+    "emoji": "👐"
+  },
+  {
+    "aliases": [
+      "eyeglasses"
+    ],
+    "description": "eyeglasses",
+    "tags": [
+      "glasses"
+    ],
+    "emoji": "👓"
+  },
+  {
+    "aliases": [
+      "womans_hat"
+    ],
+    "description": "womans hat",
+    "tags": [],
+    "emoji": "👒"
+  },
+  {
+    "aliases": [
+      "pouch"
+    ],
+    "description": "pouch",
+    "tags": [
+      "bag"
+    ],
+    "emoji": "👝"
+  },
+  {
+    "aliases": [
+      "handbag"
+    ],
+    "description": "handbag",
+    "tags": [
+      "bag"
+    ],
+    "emoji": "👜"
+  },
+  {
+    "aliases": [
+      "athletic_shoe"
+    ],
+    "description": "athletic shoe",
+    "tags": [
+      "sneaker",
+      "sport",
+      "running"
+    ],
+    "emoji": "👟"
+  },
+  {
+    "aliases": [
+      "mans_shoe",
+      "shoe"
+    ],
+    "description": "mans shoe",
+    "tags": [],
+    "emoji": "👞"
+  },
+  {
+    "aliases": [
+      "bikini"
+    ],
+    "description": "bikini",
+    "tags": [
+      "beach"
+    ],
+    "emoji": "👙"
+  },
+  {
+    "aliases": [
+      "kimono"
+    ],
+    "description": "kimono",
+    "tags": [],
+    "emoji": "👘"
+  },
+  {
+    "aliases": [
+      "purse"
+    ],
+    "description": "purse",
+    "tags": [],
+    "emoji": "👛"
+  },
+  {
+    "aliases": [
+      "womans_clothes"
+    ],
+    "description": "womans clothes",
+    "tags": [],
+    "emoji": "👚"
+  },
+  {
+    "aliases": [
+      "tongue"
+    ],
+    "description": "tongue",
+    "tags": [
+      "taste"
+    ],
+    "emoji": "👅"
+  },
+  {
+    "aliases": [
+      "lips"
+    ],
+    "description": "mouth",
+    "tags": [
+      "kiss"
+    ],
+    "emoji": "👄"
+  },
+  {
+    "aliases": [
+      "point_down"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "white down pointing backhand index",
+    "tags": [],
+    "emoji": "👇"
+  },
+  {
+    "aliases": [
+      "point_up_2"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "white up pointing backhand index",
+    "tags": [],
+    "emoji": "👆"
+  },
+  {
+    "aliases": [
+      "flag-bz",
+      "bz"
+    ],
+    "emoji": "🇧🇿",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter z",
+    "tags": [
+      "flag",
+      "belize"
     ]
   },
   {
-    "emoji": "👀",
-    "description": "eyes",
     "aliases": [
       "eyes"
     ],
+    "description": "eyes",
     "tags": [
       "look",
       "see",
       "watch"
-    ]
+    ],
+    "emoji": "👀"
   },
   {
-    "emoji": "👃",
-    "description": "nose",
-    "supports_fitzpatrick": true,
     "aliases": [
       "nose"
     ],
+    "supports_fitzpatrick": true,
+    "description": "nose",
     "tags": [
       "smell"
-    ]
-  },
-  {
-    "emoji": "👅",
-    "description": "tongue",
-    "aliases": [
-      "tongue"
     ],
-    "tags": [
-      "taste"
-    ]
+    "emoji": "👃"
   },
   {
-    "emoji": "👄",
-    "description": "mouth",
     "aliases": [
-      "lips"
+      "ear"
     ],
-    "tags": [
-      "kiss"
-    ]
-  },
-  {
-    "emoji": "👍",
-    "description": "thumbs up sign",
     "supports_fitzpatrick": true,
+    "description": "ear",
+    "tags": [
+      "hear",
+      "sound",
+      "listen"
+    ],
+    "emoji": "👂"
+  },
+  {
     "aliases": [
       "+1",
       "thumbsup"
     ],
+    "supports_fitzpatrick": true,
+    "description": "thumbs up sign",
     "tags": [
       "approve",
       "ok"
-    ]
-  },
-  {
-    "emoji": "👎",
-    "description": "thumbs down sign",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "-1",
-      "thumbsdown"
     ],
-    "tags": [
-      "disapprove",
-      "bury"
-    ]
+    "emoji": "👍"
   },
   {
-    "emoji": "👌",
-    "description": "ok hand sign",
-    "supports_fitzpatrick": true,
     "aliases": [
       "ok_hand"
     ],
-    "tags": [
-    ]
+    "supports_fitzpatrick": true,
+    "description": "ok hand sign",
+    "tags": [],
+    "emoji": "👌"
   },
   {
-    "emoji": "👊",
-    "description": "fisted hand sign",
+    "aliases": [
+      "clap"
+    ],
     "supports_fitzpatrick": true,
+    "description": "clapping hands sign",
+    "tags": [
+      "praise",
+      "applause"
+    ],
+    "emoji": "👏"
+  },
+  {
+    "aliases": [
+      "thumbsdown",
+      "-1"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "thumbs down sign",
+    "tags": [
+      "disapprove",
+      "bury"
+    ],
+    "emoji": "👎"
+  },
+  {
+    "aliases": [
+      "point_right"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "white right pointing backhand index",
+    "tags": [],
+    "emoji": "👉"
+  },
+  {
+    "aliases": [
+      "point_left"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "white left pointing backhand index",
+    "tags": [],
+    "emoji": "👈"
+  },
+  {
+    "aliases": [
+      "wave"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "waving hand sign",
+    "tags": [
+      "goodbye"
+    ],
+    "emoji": "👋"
+  },
+  {
     "aliases": [
       "facepunch",
       "punch"
     ],
+    "supports_fitzpatrick": true,
+    "description": "fisted hand sign",
     "tags": [
       "attack"
-    ]
-  },
-  {
-    "emoji": "✊",
-    "description": "raised fist",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "fist"
     ],
-    "tags": [
-      "power"
-    ]
+    "emoji": "👊"
   },
   {
-    "emoji": "✌",
-    "description": "victory hand",
-    "supports_fitzpatrick": true,
     "aliases": [
-      "v"
+      "monkey_face"
     ],
-    "tags": [
-      "victory",
-      "peace"
-    ]
+    "description": "monkey face",
+    "tags": [],
+    "emoji": "🐵"
   },
   {
-    "emoji": "👋",
-    "description": "waving hand sign",
-    "supports_fitzpatrick": true,
     "aliases": [
-      "wave"
+      "horse"
     ],
-    "tags": [
-      "goodbye"
-    ]
+    "description": "horse face",
+    "tags": [],
+    "emoji": "🐴"
   },
   {
-    "emoji": "✋",
-    "description": "raised hand",
-    "supports_fitzpatrick": true,
     "aliases": [
-      "hand",
-      "raised_hand"
+      "pig"
     ],
-    "tags": [
-      "highfive",
-      "stop"
-    ]
+    "description": "pig face",
+    "tags": [],
+    "emoji": "🐷"
   },
   {
-    "emoji": "👐",
-    "description": "open hands sign",
-    "supports_fitzpatrick": true,
     "aliases": [
-      "open_hands"
+      "dog"
     ],
+    "description": "dog face",
     "tags": [
-    ]
+      "pet"
+    ],
+    "emoji": "🐶"
   },
   {
-    "emoji": "👆",
-    "description": "white up pointing backhand index",
-    "supports_fitzpatrick": true,
     "aliases": [
-      "point_up_2"
+      "cat"
     ],
+    "description": "cat face",
     "tags": [
-    ]
+      "pet"
+    ],
+    "emoji": "🐱"
   },
   {
-    "emoji": "👇",
-    "description": "white down pointing backhand index",
-    "supports_fitzpatrick": true,
     "aliases": [
-      "point_down"
+      "rabbit"
     ],
+    "description": "rabbit face",
     "tags": [
-    ]
+      "bunny"
+    ],
+    "emoji": "🐰"
   },
   {
-    "emoji": "👉",
-    "description": "white right pointing backhand index",
-    "supports_fitzpatrick": true,
     "aliases": [
-      "point_right"
+      "whale"
     ],
+    "description": "spouting whale",
     "tags": [
-    ]
+      "sea"
+    ],
+    "emoji": "🐳"
   },
   {
-    "emoji": "👈",
-    "description": "white left pointing backhand index",
-    "supports_fitzpatrick": true,
     "aliases": [
-      "point_left"
+      "dragon_face"
     ],
-    "tags": [
-    ]
+    "description": "dragon face",
+    "tags": [],
+    "emoji": "🐲"
   },
   {
-    "emoji": "🙌",
-    "description": "person raising both hands in celebration",
-    "supports_fitzpatrick": true,
     "aliases": [
-      "raised_hands"
+      "pig_nose"
     ],
-    "tags": [
-      "hooray"
-    ]
+    "description": "pig nose",
+    "tags": [],
+    "emoji": "🐽"
   },
   {
-    "emoji": "🙏",
-    "description": "person with folded hands",
-    "supports_fitzpatrick": true,
     "aliases": [
-      "pray"
+      "panda_face"
     ],
-    "tags": [
-      "please",
-      "hope",
-      "wish"
-    ]
+    "description": "panda face",
+    "tags": [],
+    "emoji": "🐼"
   },
   {
-    "emoji": "☝",
-    "description": "white up pointing index",
     "aliases": [
-      "point_up"
+      "regional_indicator_symbol_w"
     ],
+    "emoji": "🇼",
+    "description": "regional indicator symbol letter w",
     "tags": [
+      "letter",
+      "w"
     ]
   },
   {
-    "emoji": "👏",
-    "description": "clapping hands sign",
-    "supports_fitzpatrick": true,
     "aliases": [
-      "clap"
+      "feet",
+      "paw_prints"
     ],
-    "tags": [
-      "praise",
-      "applause"
-    ]
+    "description": "paw prints",
+    "tags": [],
+    "emoji": "🐾"
   },
   {
-    "emoji": "💪",
-    "description": "flexed biceps",
-    "supports_fitzpatrick": true,
+    "aliases": [
+      "hamster"
+    ],
+    "description": "hamster face",
+    "tags": [
+      "pet"
+    ],
+    "emoji": "🐹"
+  },
+  {
+    "aliases": [
+      "frog"
+    ],
+    "description": "frog face",
+    "tags": [],
+    "emoji": "🐸"
+  },
+  {
+    "aliases": [
+      "bear"
+    ],
+    "description": "bear face",
+    "tags": [],
+    "emoji": "🐻"
+  },
+  {
+    "aliases": [
+      "wolf"
+    ],
+    "description": "wolf face",
+    "tags": [],
+    "emoji": "🐺"
+  },
+  {
+    "aliases": [
+      "hatched_chick"
+    ],
+    "description": "front-facing baby chick",
+    "tags": [],
+    "emoji": "🐥"
+  },
+  {
+    "aliases": [
+      "baby_chick"
+    ],
+    "description": "baby chick",
+    "tags": [],
+    "emoji": "🐤"
+  },
+  {
+    "aliases": [
+      "penguin"
+    ],
+    "description": "penguin",
+    "tags": [],
+    "emoji": "🐧"
+  },
+  {
+    "aliases": [
+      "bird"
+    ],
+    "description": "bird",
+    "tags": [],
+    "emoji": "🐦"
+  },
+  {
+    "aliases": [
+      "blowfish"
+    ],
+    "description": "blowfish",
+    "tags": [],
+    "emoji": "🐡"
+  },
+  {
+    "aliases": [
+      "tropical_fish"
+    ],
+    "description": "tropical fish",
+    "tags": [],
+    "emoji": "🐠"
+  },
+  {
+    "aliases": [
+      "hatching_chick"
+    ],
+    "description": "hatching chick",
+    "tags": [],
+    "emoji": "🐣"
+  },
+  {
+    "aliases": [
+      "turtle"
+    ],
+    "description": "turtle",
+    "tags": [
+      "slow"
+    ],
+    "emoji": "🐢"
+  },
+  {
+    "aliases": [
+      "mouse"
+    ],
+    "description": "mouse face",
+    "tags": [],
+    "emoji": "🐭"
+  },
+  {
+    "aliases": [
+      "flipper",
+      "dolphin"
+    ],
+    "description": "dolphin",
+    "tags": [],
+    "emoji": "🐬"
+  },
+  {
+    "aliases": [
+      "tiger"
+    ],
+    "description": "tiger face",
+    "tags": [],
+    "emoji": "🐯"
+  },
+  {
+    "aliases": [
+      "cow"
+    ],
+    "description": "cow face",
+    "tags": [],
+    "emoji": "🐮"
+  },
+  {
+    "aliases": [
+      "poodle"
+    ],
+    "description": "poodle",
+    "tags": [
+      "dog"
+    ],
+    "emoji": "🐩"
+  },
+  {
+    "aliases": [
+      "koala"
+    ],
+    "description": "koala",
+    "tags": [],
+    "emoji": "🐨"
+  },
+  {
+    "aliases": [
+      "camel"
+    ],
+    "description": "bactrian camel",
+    "tags": [],
+    "emoji": "🐫"
+  },
+  {
+    "aliases": [
+      "dromedary_camel"
+    ],
+    "description": "dromedary camel",
+    "tags": [
+      "desert"
+    ],
+    "emoji": "🐪"
+  },
+  {
+    "aliases": [
+      "dog2"
+    ],
+    "description": "dog",
+    "tags": [],
+    "emoji": "🐕"
+  },
+  {
+    "aliases": [
+      "chicken"
+    ],
+    "description": "chicken",
+    "tags": [],
+    "emoji": "🐔"
+  },
+  {
+    "aliases": [
+      "boar"
+    ],
+    "description": "boar",
+    "tags": [],
+    "emoji": "🐗"
+  },
+  {
+    "aliases": [
+      "pig2"
+    ],
+    "description": "pig",
+    "tags": [],
+    "emoji": "🐖"
+  },
+  {
+    "aliases": [
+      "sheep"
+    ],
+    "description": "sheep",
+    "tags": [],
+    "emoji": "🐑"
+  },
+  {
+    "aliases": [
+      "goat"
+    ],
+    "description": "goat",
+    "tags": [],
+    "emoji": "🐐"
+  },
+  {
+    "aliases": [
+      "rooster"
+    ],
+    "description": "rooster",
+    "tags": [],
+    "emoji": "🐓"
+  },
+  {
+    "aliases": [
+      "monkey"
+    ],
+    "description": "monkey",
+    "tags": [],
+    "emoji": "🐒"
+  },
+  {
+    "aliases": [
+      "honeybee",
+      "bee"
+    ],
+    "description": "honeybee",
+    "tags": [],
+    "emoji": "🐝"
+  },
+  {
+    "aliases": [
+      "ant"
+    ],
+    "description": "ant",
+    "tags": [],
+    "emoji": "🐜"
+  },
+  {
+    "aliases": [
+      "fish"
+    ],
+    "description": "fish",
+    "tags": [],
+    "emoji": "🐟"
+  },
+  {
+    "aliases": [
+      "beetle"
+    ],
+    "description": "lady beetle",
+    "tags": [
+      "bug"
+    ],
+    "emoji": "🐞"
+  },
+  {
+    "aliases": [
+      "octopus"
+    ],
+    "description": "octopus",
+    "tags": [],
+    "emoji": "🐙"
+  },
+  {
+    "aliases": [
+      "elephant"
+    ],
+    "description": "elephant",
+    "tags": [],
+    "emoji": "🐘"
+  },
+  {
+    "aliases": [
+      "bug"
+    ],
+    "description": "bug",
+    "tags": [],
+    "emoji": "🐛"
+  },
+  {
+    "aliases": [
+      "shell"
+    ],
+    "description": "spiral shell",
+    "tags": [
+      "sea",
+      "beach"
+    ],
+    "emoji": "🐚"
+  },
+  {
+    "aliases": [
+      "tiger2"
+    ],
+    "description": "tiger",
+    "tags": [],
+    "emoji": "🐅"
+  },
+  {
+    "aliases": [
+      "cow2"
+    ],
+    "description": "cow",
+    "tags": [],
+    "emoji": "🐄"
+  },
+  {
+    "aliases": [
+      "rabbit2"
+    ],
+    "description": "rabbit",
+    "tags": [],
+    "emoji": "🐇"
+  },
+  {
+    "aliases": [
+      "leopard"
+    ],
+    "description": "leopard",
+    "tags": [],
+    "emoji": "🐆"
+  },
+  {
+    "aliases": [
+      "mouse2"
+    ],
+    "description": "mouse",
+    "tags": [],
+    "emoji": "🐁"
+  },
+  {
+    "aliases": [
+      "rat"
+    ],
+    "description": "rat",
+    "tags": [],
+    "emoji": "🐀"
+  },
+  {
+    "aliases": [
+      "water_buffalo"
+    ],
+    "description": "water buffalo",
+    "tags": [],
+    "emoji": "🐃"
+  },
+  {
+    "aliases": [
+      "ox"
+    ],
+    "description": "ox",
+    "tags": [],
+    "emoji": "🐂"
+  },
+  {
+    "aliases": [
+      "snake"
+    ],
+    "description": "snake",
+    "tags": [],
+    "emoji": "🐍"
+  },
+  {
+    "aliases": [
+      "snail"
+    ],
+    "description": "snail",
+    "tags": [
+      "slow"
+    ],
+    "emoji": "🐌"
+  },
+  {
+    "aliases": [
+      "ram"
+    ],
+    "description": "ram",
+    "tags": [],
+    "emoji": "🐏"
+  },
+  {
+    "aliases": [
+      "racehorse"
+    ],
+    "description": "horse",
+    "tags": [
+      "speed"
+    ],
+    "emoji": "🐎"
+  },
+  {
+    "aliases": [
+      "dragon"
+    ],
+    "description": "dragon",
+    "tags": [],
+    "emoji": "🐉"
+  },
+  {
+    "aliases": [
+      "cat2"
+    ],
+    "description": "cat",
+    "tags": [],
+    "emoji": "🐈"
+  },
+  {
+    "aliases": [
+      "whale2"
+    ],
+    "description": "whale",
+    "tags": [],
+    "emoji": "🐋"
+  },
+  {
+    "aliases": [
+      "umbrella_with_rain_drops",
+      "umbrella"
+    ],
+    "description": "umbrella with rain drops",
+    "tags": [
+      "rain",
+      "weather"
+    ],
+    "emoji": "☔"
+  },
+  {
+    "aliases": [
+      "no_mobile_phones"
+    ],
+    "description": "no mobile phones",
+    "tags": [],
+    "emoji": "📵"
+  },
+  {
+    "aliases": [
+      "sake"
+    ],
+    "description": "sake bottle and cup",
+    "tags": [],
+    "emoji": "🍶"
+  },
+  {
+    "aliases": [
+      "camera"
+    ],
+    "description": "camera",
+    "tags": [
+      "photo"
+    ],
+    "emoji": "📷"
+  },
+  {
+    "aliases": [
+      "signal_strength"
+    ],
+    "description": "antenna with bars",
+    "tags": [
+      "wifi"
+    ],
+    "emoji": "📶"
+  },
+  {
+    "aliases": [
+      "iphone"
+    ],
+    "description": "mobile phone",
+    "tags": [
+      "smartphone",
+      "mobile"
+    ],
+    "emoji": "📱"
+  },
+  {
+    "aliases": [
+      "newspaper"
+    ],
+    "description": "newspaper",
+    "tags": [
+      "press"
+    ],
+    "emoji": "📰"
+  },
+  {
+    "aliases": [
+      "vibration_mode"
+    ],
+    "description": "vibration mode",
+    "tags": [],
+    "emoji": "📳"
+  },
+  {
+    "aliases": [
+      "calling"
+    ],
+    "description": "mobile phone with rightwards arrow at left",
+    "tags": [
+      "call",
+      "incoming"
+    ],
+    "emoji": "📲"
+  },
+  {
+    "aliases": [
+      "film_projector"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "film projector",
+    "tags": [],
+    "emoji": "📽"
+  },
+  {
+    "aliases": [
+      "vhs"
+    ],
+    "description": "videocassette",
+    "tags": [],
+    "emoji": "📼"
+  },
+  {
+    "aliases": [
+      "rosary_beads",
+      "dhikr_beads",
+      "prayer_beads"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "prayer beads",
+    "tags": [],
+    "emoji": "📿"
+  },
+  {
+    "aliases": [
+      "non-potable_water"
+    ],
+    "description": "non-potable water symbol",
+    "tags": [],
+    "emoji": "🚱"
+  },
+  {
+    "aliases": [
+      "video_camera"
+    ],
+    "description": "video camera",
+    "tags": [],
+    "emoji": "📹"
+  },
+  {
+    "aliases": [
+      "no_pedestrians"
+    ],
+    "description": "no pedestrians",
+    "tags": [],
+    "emoji": "🚷"
+  },
+  {
+    "aliases": [
+      "radio"
+    ],
+    "description": "radio",
+    "tags": [
+      "podcast"
+    ],
+    "emoji": "📻"
+  },
+  {
+    "aliases": [
+      "tv"
+    ],
+    "description": "television",
+    "tags": [],
+    "emoji": "📺"
+  },
+  {
+    "aliases": [
+      "inbox_tray"
+    ],
+    "description": "inbox tray",
+    "tags": [],
+    "emoji": "📥"
+  },
+  {
+    "aliases": [
+      "outbox_tray"
+    ],
+    "description": "outbox tray",
+    "tags": [],
+    "emoji": "📤"
+  },
+  {
+    "aliases": [
+      "e-mail"
+    ],
+    "description": "e-mail symbol",
+    "tags": [],
+    "emoji": "📧"
+  },
+  {
+    "aliases": [
+      "package"
+    ],
+    "description": "package",
+    "tags": [
+      "shipping"
+    ],
+    "emoji": "📦"
+  },
+  {
+    "aliases": [
+      "satellite",
+      "satellite_antenna"
+    ],
+    "description": "satellite antenna",
+    "tags": [
+      "signal"
+    ],
+    "emoji": "📡"
+  },
+  {
+    "aliases": [
+      "fax"
+    ],
+    "description": "fax machine",
+    "tags": [],
+    "emoji": "📠"
+  },
+  {
+    "aliases": [
+      "mega"
+    ],
+    "description": "cheering megaphone",
+    "tags": [],
+    "emoji": "📣"
+  },
+  {
+    "aliases": [
+      "loudspeaker"
+    ],
+    "description": "public address loudspeaker",
+    "tags": [
+      "announcement"
+    ],
+    "emoji": "📢"
+  },
+  {
+    "aliases": [
+      "mailbox_with_no_mail"
+    ],
+    "description": "open mailbox with lowered flag",
+    "tags": [],
+    "emoji": "📭"
+  },
+  {
+    "aliases": [
+      "mailbox_with_mail"
+    ],
+    "description": "open mailbox with raised flag",
+    "tags": [],
+    "emoji": "📬"
+  },
+  {
+    "aliases": [
+      "postal_horn"
+    ],
+    "description": "postal horn",
+    "tags": [],
+    "emoji": "📯"
+  },
+  {
+    "aliases": [
+      "postbox"
+    ],
+    "description": "postbox",
+    "tags": [],
+    "emoji": "📮"
+  },
+  {
+    "aliases": [
+      "envelope_with_arrow"
+    ],
+    "description": "envelope with downwards arrow above",
+    "tags": [],
+    "emoji": "📩"
+  },
+  {
+    "aliases": [
+      "incoming_envelope"
+    ],
+    "description": "incoming envelope",
+    "tags": [],
+    "emoji": "📨"
+  },
+  {
+    "aliases": [
+      "mailbox"
+    ],
+    "description": "closed mailbox with raised flag",
+    "tags": [],
+    "emoji": "📫"
+  },
+  {
+    "aliases": [
+      "mailbox_closed"
+    ],
+    "description": "closed mailbox with lowered flag",
+    "tags": [],
+    "emoji": "📪"
+  },
+  {
+    "aliases": [
+      "closed_book"
+    ],
+    "description": "closed book",
+    "tags": [],
+    "emoji": "📕"
+  },
+  {
+    "aliases": [
+      "notebook_with_decorative_cover"
+    ],
+    "description": "notebook with decorative cover",
+    "tags": [],
+    "emoji": "📔"
+  },
+  {
+    "aliases": [
+      "green_book"
+    ],
+    "description": "green book",
+    "tags": [],
+    "emoji": "📗"
+  },
+  {
+    "aliases": [
+      "open_book",
+      "book"
+    ],
+    "description": "open book",
+    "tags": [],
+    "emoji": "📖"
+  },
+  {
+    "aliases": [
+      "bookmark_tabs"
+    ],
+    "description": "bookmark tabs",
+    "tags": [],
+    "emoji": "📑"
+  },
+  {
+    "aliases": [
+      "triangular_ruler"
+    ],
+    "description": "triangular ruler",
+    "tags": [],
+    "emoji": "📐"
+  },
+  {
+    "aliases": [
+      "notebook"
+    ],
+    "description": "notebook",
+    "tags": [],
+    "emoji": "📓"
+  },
+  {
+    "aliases": [
+      "ledger"
+    ],
+    "description": "ledger",
+    "tags": [],
+    "emoji": "📒"
+  },
+  {
+    "aliases": [
+      "pencil",
+      "memo"
+    ],
+    "description": "memo",
+    "tags": [
+      "document",
+      "note"
+    ],
+    "emoji": "📝"
+  },
+  {
+    "aliases": [
+      "scroll"
+    ],
+    "description": "scroll",
+    "tags": [
+      "document"
+    ],
+    "emoji": "📜"
+  },
+  {
+    "aliases": [
+      "pager"
+    ],
+    "description": "pager",
+    "tags": [],
+    "emoji": "📟"
+  },
+  {
+    "aliases": [
+      "telephone_receiver"
+    ],
+    "description": "telephone receiver",
+    "tags": [
+      "phone",
+      "call"
+    ],
+    "emoji": "📞"
+  },
+  {
+    "aliases": [
+      "orange_book"
+    ],
+    "description": "orange book",
+    "tags": [],
+    "emoji": "📙"
+  },
+  {
+    "aliases": [
+      "blue_book"
+    ],
+    "description": "blue book",
+    "tags": [],
+    "emoji": "📘"
+  },
+  {
+    "aliases": [
+      "name_badge"
+    ],
+    "description": "name badge",
+    "tags": [],
+    "emoji": "📛"
+  },
+  {
+    "aliases": [
+      "books"
+    ],
+    "description": "books",
+    "tags": [
+      "library"
+    ],
+    "emoji": "📚"
+  },
+  {
+    "aliases": [
+      "date"
+    ],
+    "description": "calendar",
+    "tags": [
+      "calendar",
+      "schedule"
+    ],
+    "emoji": "📅"
+  },
+  {
+    "aliases": [
+      "page_facing_up"
+    ],
+    "description": "page facing up",
+    "tags": [
+      "document"
+    ],
+    "emoji": "📄"
+  },
+  {
+    "aliases": [
+      "card_index"
+    ],
+    "description": "card index",
+    "tags": [],
+    "emoji": "📇"
+  },
+  {
+    "aliases": [
+      "calendar"
+    ],
+    "description": "tear-off calendar",
+    "tags": [
+      "schedule"
+    ],
+    "emoji": "📆"
+  },
+  {
+    "aliases": [
+      "file_folder"
+    ],
+    "description": "file folder",
+    "tags": [
+      "directory"
+    ],
+    "emoji": "📁"
+  },
+  {
+    "aliases": [
+      "dvd"
+    ],
+    "description": "dvd",
+    "tags": [],
+    "emoji": "📀"
+  },
+  {
+    "aliases": [
+      "page_with_curl"
+    ],
+    "description": "page with curl",
+    "tags": [],
+    "emoji": "📃"
+  },
+  {
+    "aliases": [
+      "open_file_folder"
+    ],
+    "description": "open file folder",
+    "tags": [],
+    "emoji": "📂"
+  },
+  {
+    "aliases": [
+      "round_pushpin"
+    ],
+    "description": "round pushpin",
+    "tags": [
+      "location"
+    ],
+    "emoji": "📍"
+  },
+  {
+    "aliases": [
+      "pushpin"
+    ],
+    "description": "pushpin",
+    "tags": [
+      "location"
+    ],
+    "emoji": "📌"
+  },
+  {
+    "aliases": [
+      "straight_ruler"
+    ],
+    "description": "straight ruler",
+    "tags": [],
+    "emoji": "📏"
+  },
+  {
+    "aliases": [
+      "paperclip"
+    ],
+    "description": "paperclip",
+    "tags": [],
+    "emoji": "📎"
+  },
+  {
+    "aliases": [
+      "chart_with_downwards_trend"
+    ],
+    "description": "chart with downwards trend",
+    "tags": [
+      "graph",
+      "metrics"
+    ],
+    "emoji": "📉"
+  },
+  {
+    "aliases": [
+      "chart_with_upwards_trend"
+    ],
+    "description": "chart with upwards trend",
+    "tags": [
+      "graph",
+      "metrics"
+    ],
+    "emoji": "📈"
+  },
+  {
+    "aliases": [
+      "clipboard"
+    ],
+    "description": "clipboard",
+    "tags": [],
+    "emoji": "📋"
+  },
+  {
+    "aliases": [
+      "bar_chart"
+    ],
+    "description": "bar chart",
+    "tags": [
+      "stats",
+      "metrics"
+    ],
+    "emoji": "📊"
+  },
+  {
+    "aliases": [
+      "dollar"
+    ],
+    "description": "banknote with dollar sign",
+    "tags": [
+      "money"
+    ],
+    "emoji": "💵"
+  },
+  {
+    "aliases": [
+      "yen"
+    ],
+    "description": "banknote with yen sign",
+    "tags": [],
+    "emoji": "💴"
+  },
+  {
+    "aliases": [
+      "pound"
+    ],
+    "description": "banknote with pound sign",
+    "tags": [],
+    "emoji": "💷"
+  },
+  {
+    "aliases": [
+      "euro"
+    ],
+    "description": "banknote with euro sign",
+    "tags": [],
+    "emoji": "💶"
+  },
+  {
+    "aliases": [
+      "currency_exchange"
+    ],
+    "description": "currency exchange",
+    "tags": [],
+    "emoji": "💱"
+  },
+  {
+    "aliases": [
+      "snowman",
+      "snowman_without_snow"
+    ],
+    "description": "snowman without snow",
+    "tags": [
+      "winter",
+      "christmas"
+    ],
+    "emoji": "⛄"
+  },
+  {
+    "aliases": [
+      "credit_card"
+    ],
+    "description": "credit card",
+    "tags": [
+      "subscription"
+    ],
+    "emoji": "💳"
+  },
+  {
+    "aliases": [
+      "ok"
+    ],
+    "description": "squared ok",
+    "tags": [
+      "yes"
+    ],
+    "emoji": "🆗"
+  },
+  {
+    "aliases": [
+      "minidisc"
+    ],
+    "description": "minidisc",
+    "tags": [],
+    "emoji": "💽"
+  },
+  {
+    "aliases": [
+      "briefcase"
+    ],
+    "description": "briefcase",
+    "tags": [
+      "business"
+    ],
+    "emoji": "💼"
+  },
+  {
+    "aliases": [
+      "cd"
+    ],
+    "description": "optical disc",
+    "tags": [],
+    "emoji": "💿"
+  },
+  {
+    "aliases": [
+      "floppy_disk"
+    ],
+    "description": "floppy disk",
+    "tags": [
+      "save"
+    ],
+    "emoji": "💾"
+  },
+  {
+    "aliases": [
+      "chart"
+    ],
+    "description": "chart with upwards trend and yen sign",
+    "tags": [],
+    "emoji": "💹"
+  },
+  {
+    "aliases": [
+      "money_with_wings"
+    ],
+    "description": "money with wings",
+    "tags": [
+      "dollar"
+    ],
+    "emoji": "💸"
+  },
+  {
+    "aliases": [
+      "computer"
+    ],
+    "description": "personal computer",
+    "tags": [
+      "desktop",
+      "screen"
+    ],
+    "emoji": "💻"
+  },
+  {
+    "aliases": [
+      "seat"
+    ],
+    "description": "seat",
+    "tags": [],
+    "emoji": "💺"
+  },
+  {
+    "aliases": [
+      "collision",
+      "boom"
+    ],
+    "description": "collision symbol",
+    "tags": [
+      "explode"
+    ],
+    "emoji": "💥"
+  },
+  {
+    "aliases": [
+      "zzz"
+    ],
+    "description": "sleeping symbol",
+    "tags": [
+      "sleeping"
+    ],
+    "emoji": "💤"
+  },
+  {
+    "aliases": [
+      "droplet"
+    ],
+    "description": "droplet",
+    "tags": [
+      "water"
+    ],
+    "emoji": "💧"
+  },
+  {
+    "aliases": [
+      "sweat_drops"
+    ],
+    "description": "splashing sweat symbol",
+    "tags": [
+      "water",
+      "workout"
+    ],
+    "emoji": "💦"
+  },
+  {
+    "aliases": [
+      "bulb"
+    ],
+    "description": "electric light bulb",
+    "tags": [
+      "idea",
+      "light"
+    ],
+    "emoji": "💡"
+  },
+  {
+    "aliases": [
+      "restroom"
+    ],
+    "description": "restroom",
+    "tags": [
+      "toilet"
+    ],
+    "emoji": "🚻"
+  },
+  {
+    "aliases": [
+      "bomb"
+    ],
+    "description": "bomb",
+    "tags": [
+      "boom"
+    ],
+    "emoji": "💣"
+  },
+  {
+    "aliases": [
+      "anger"
+    ],
+    "description": "anger symbol",
+    "tags": [
+      "angry"
+    ],
+    "emoji": "💢"
+  },
+  {
+    "aliases": [
+      "thought_balloon"
+    ],
+    "description": "thought balloon",
+    "tags": [
+      "thinking"
+    ],
+    "emoji": "💭"
+  },
+  {
+    "aliases": [
+      "speech_balloon"
+    ],
+    "description": "speech balloon",
+    "tags": [
+      "comment"
+    ],
+    "emoji": "💬"
+  },
+  {
+    "aliases": [
+      "100"
+    ],
+    "description": "hundred points symbol",
+    "tags": [
+      "score",
+      "perfect"
+    ],
+    "emoji": "💯"
+  },
+  {
+    "aliases": [
+      "womens"
+    ],
+    "description": "womens symbol",
+    "tags": [],
+    "emoji": "🚺"
+  },
+  {
+    "aliases": [
+      "poop",
+      "hankey",
+      "shit"
+    ],
+    "description": "pile of poo",
+    "tags": [
+      "crap"
+    ],
+    "emoji": "💩"
+  },
+  {
+    "aliases": [
+      "dash"
+    ],
+    "description": "dash symbol",
+    "tags": [
+      "wind",
+      "blow",
+      "fast"
+    ],
+    "emoji": "💨"
+  },
+  {
+    "aliases": [
+      "dizzy"
+    ],
+    "description": "dizzy symbol",
+    "tags": [
+      "star"
+    ],
+    "emoji": "💫"
+  },
+  {
     "aliases": [
       "muscle"
     ],
+    "supports_fitzpatrick": true,
+    "description": "flexed biceps",
     "tags": [
       "flex",
       "bicep",
       "strong",
       "workout"
-    ]
-  },
-  {
-    "emoji": "🚶",
-    "description": "pedestrian",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "walking"
     ],
-    "tags": [
-    ]
+    "emoji": "💪"
   },
   {
-    "emoji": "🏃",
-    "description": "runner",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "runner",
-      "running"
-    ],
-    "tags": [
-      "exercise",
-      "workout",
-      "marathon"
-    ]
-  },
-  {
-    "emoji": "💃",
-    "description": "dancer",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "dancer"
-    ],
-    "tags": [
-      "dress"
-    ]
-  },
-  {
-    "emoji": "👫",
-    "description": "man and woman holding hands",
-    "aliases": [
-      "couple"
-    ],
-    "tags": [
-      "date"
-    ]
-  },
-  {
-    "emoji": "👪",
-    "description": "family",
-    "aliases": [
-      "family"
-    ],
-    "tags": [
-      "home",
-      "parents",
-      "child"
-    ]
-  },
-  {
-    "emoji": "👬",
-    "description": "two men holding hands",
-    "aliases": [
-      "two_men_holding_hands"
-    ],
-    "tags": [
-      "couple",
-      "date"
-    ]
-  },
-  {
-    "emoji": "👭",
-    "description": "two women holding hands",
-    "aliases": [
-      "two_women_holding_hands"
-    ],
-    "tags": [
-      "couple",
-      "date"
-    ]
-  },
-  {
-    "emoji": "💏",
-    "description": "kiss",
-    "aliases": [
-      "couplekiss"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "💑",
-    "description": "couple with heart",
-    "aliases": [
-      "couple_with_heart"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "👯",
-    "description": "woman with bunny ears",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "dancers"
-    ],
-    "tags": [
-      "bunny"
-    ]
-  },
-  {
-    "emoji": "🙆",
-    "description": "face with ok gesture",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "ok_woman"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🙅",
-    "description": "face with no good gesture",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "no_good"
-    ],
-    "tags": [
-      "stop",
-      "halt"
-    ]
-  },
-  {
-    "emoji": "💁",
-    "description": "information desk person",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "information_desk_person"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🙋",
-    "description": "happy person raising one hand",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "raising_hand"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "💆",
-    "description": "face massage",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "massage"
-    ],
-    "tags": [
-      "spa"
-    ]
-  },
-  {
-    "emoji": "💇",
-    "description": "haircut",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "haircut"
-    ],
-    "tags": [
-      "beauty"
-    ]
-  },
-  {
-    "emoji": "💅",
-    "description": "nail polish",
-    "aliases": [
-      "nail_care"
-    ],
-    "tags": [
-      "beauty",
-      "manicure"
-    ]
-  },
-  {
-    "emoji": "👰",
-    "description": "bride with veil",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "bride_with_veil"
-    ],
-    "tags": [
-      "marriage",
-      "wedding"
-    ]
-  },
-  {
-    "emoji": "🙎",
-    "description": "person with pouting face",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "person_with_pouting_face"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🙍",
-    "description": "person frowning",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "person_frowning"
-    ],
-    "tags": [
-      "sad"
-    ]
-  },
-  {
-    "emoji": "🙇",
-    "description": "person bowing deeply",
-    "aliases": [
-      "bow"
-    ],
-    "tags": [
-      "respect",
-      "thanks"
-    ]
-  },
-  {
-    "emoji": "🎩",
-    "description": "top hat",
-    "aliases": [
-      "tophat"
-    ],
-    "tags": [
-      "hat",
-      "classy"
-    ]
-  },
-  {
-    "emoji": "👑",
-    "description": "crown",
-    "aliases": [
-      "crown"
-    ],
-    "tags": [
-      "king",
-      "queen",
-      "royal"
-    ]
-  },
-  {
-    "emoji": "👒",
-    "description": "womans hat",
-    "aliases": [
-      "womans_hat"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "👟",
-    "description": "athletic shoe",
-    "aliases": [
-      "athletic_shoe"
-    ],
-    "tags": [
-      "sneaker",
-      "sport",
-      "running"
-    ]
-  },
-  {
-    "emoji": "👞",
-    "description": "mans shoe",
-    "aliases": [
-      "mans_shoe",
-      "shoe"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "👡",
-    "description": "womans sandal",
-    "aliases": [
-      "sandal"
-    ],
-    "tags": [
-      "shoe"
-    ]
-  },
-  {
-    "emoji": "👠",
-    "description": "high-heeled shoe",
-    "aliases": [
-      "high_heel"
-    ],
-    "tags": [
-      "shoe"
-    ]
-  },
-  {
-    "emoji": "👢",
-    "description": "womans boots",
-    "aliases": [
-      "boot"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "👕",
-    "description": "t-shirt",
-    "aliases": [
-      "shirt",
-      "tshirt"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "👔",
-    "description": "necktie",
-    "aliases": [
-      "necktie"
-    ],
-    "tags": [
-      "shirt",
-      "formal"
-    ]
-  },
-  {
-    "emoji": "👚",
-    "description": "womans clothes",
-    "aliases": [
-      "womans_clothes"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "👗",
-    "description": "dress",
-    "aliases": [
-      "dress"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🎽",
-    "description": "running shirt with sash",
-    "aliases": [
-      "running_shirt_with_sash"
-    ],
-    "tags": [
-      "marathon"
-    ]
-  },
-  {
-    "emoji": "👖",
-    "description": "jeans",
-    "aliases": [
-      "jeans"
-    ],
-    "tags": [
-      "pants"
-    ]
-  },
-  {
-    "emoji": "👘",
-    "description": "kimono",
-    "aliases": [
-      "kimono"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "👙",
-    "description": "bikini",
-    "aliases": [
-      "bikini"
-    ],
-    "tags": [
-      "beach"
-    ]
-  },
-  {
-    "emoji": "💼",
-    "description": "briefcase",
-    "aliases": [
-      "briefcase"
-    ],
-    "tags": [
-      "business"
-    ]
-  },
-  {
-    "emoji": "👜",
-    "description": "handbag",
-    "aliases": [
-      "handbag"
-    ],
-    "tags": [
-      "bag"
-    ]
-  },
-  {
-    "emoji": "👝",
-    "description": "pouch",
-    "aliases": [
-      "pouch"
-    ],
-    "tags": [
-      "bag"
-    ]
-  },
-  {
-    "emoji": "👛",
-    "description": "purse",
-    "aliases": [
-      "purse"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "👓",
-    "description": "eyeglasses",
-    "aliases": [
-      "eyeglasses"
-    ],
-    "tags": [
-      "glasses"
-    ]
-  },
-  {
-    "emoji": "🎀",
-    "description": "ribbon",
-    "aliases": [
-      "ribbon"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🌂",
-    "description": "closed umbrella",
-    "aliases": [
-      "closed_umbrella"
-    ],
-    "tags": [
-      "weather",
-      "rain"
-    ]
-  },
-  {
-    "emoji": "💄",
-    "description": "lipstick",
-    "aliases": [
-      "lipstick"
-    ],
-    "tags": [
-      "makeup"
-    ]
-  },
-  {
-    "emoji": "💛",
-    "description": "yellow heart",
-    "aliases": [
-      "yellow_heart"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "💙",
-    "description": "blue heart",
-    "aliases": [
-      "blue_heart"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "💜",
-    "description": "purple heart",
-    "aliases": [
-      "purple_heart"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "💚",
-    "description": "green heart",
-    "aliases": [
-      "green_heart"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "❤",
-    "description": "heavy black heart",
-    "aliases": [
-      "heart"
-    ],
-    "tags": [
-      "love"
-    ]
-  },
-  {
-    "emoji": "💔",
-    "description": "broken heart",
-    "aliases": [
-      "broken_heart"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "💗",
-    "description": "growing heart",
-    "aliases": [
-      "heartpulse"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "💓",
-    "description": "beating heart",
-    "aliases": [
-      "heartbeat"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "💕",
-    "description": "two hearts",
     "aliases": [
       "two_hearts"
     ],
-    "tags": [
-    ]
+    "description": "two hearts",
+    "tags": [],
+    "emoji": "💕"
   },
   {
-    "emoji": "💖",
-    "description": "sparkling heart",
+    "aliases": [
+      "broken_heart"
+    ],
+    "description": "broken heart",
+    "tags": [],
+    "emoji": "💔"
+  },
+  {
+    "aliases": [
+      "heartpulse"
+    ],
+    "description": "growing heart",
+    "tags": [],
+    "emoji": "💗"
+  },
+  {
     "aliases": [
       "sparkling_heart"
     ],
-    "tags": [
-    ]
+    "description": "sparkling heart",
+    "tags": [],
+    "emoji": "💖"
   },
   {
-    "emoji": "💞",
-    "description": "revolving hearts",
+    "aliases": [
+      "couple_with_heart"
+    ],
+    "description": "couple with heart",
+    "tags": [],
+    "emoji": "💑"
+  },
+  {
+    "aliases": [
+      "bouquet"
+    ],
+    "description": "bouquet",
+    "tags": [
+      "flowers"
+    ],
+    "emoji": "💐"
+  },
+  {
+    "aliases": [
+      "heartbeat"
+    ],
+    "description": "beating heart",
+    "tags": [],
+    "emoji": "💓"
+  },
+  {
+    "aliases": [
+      "wedding"
+    ],
+    "description": "wedding",
+    "tags": [
+      "marriage"
+    ],
+    "emoji": "💒"
+  },
+  {
+    "aliases": [
+      "gift_heart"
+    ],
+    "description": "heart with ribbon",
+    "tags": [
+      "chocolates"
+    ],
+    "emoji": "💝"
+  },
+  {
+    "aliases": [
+      "purple_heart"
+    ],
+    "description": "purple heart",
+    "tags": [],
+    "emoji": "💜"
+  },
+  {
+    "aliases": [
+      "heart_decoration"
+    ],
+    "description": "heart decoration",
+    "tags": [],
+    "emoji": "💟"
+  },
+  {
     "aliases": [
       "revolving_hearts"
     ],
-    "tags": [
-    ]
+    "description": "revolving hearts",
+    "tags": [],
+    "emoji": "💞"
   },
   {
-    "emoji": "💘",
-    "description": "heart with arrow",
+    "aliases": [
+      "blue_heart"
+    ],
+    "description": "blue heart",
+    "tags": [],
+    "emoji": "💙"
+  },
+  {
     "aliases": [
       "cupid"
     ],
+    "description": "heart with arrow",
     "tags": [
       "love",
       "heart"
-    ]
+    ],
+    "emoji": "💘"
   },
   {
-    "emoji": "💌",
-    "description": "love letter",
     "aliases": [
-      "love_letter"
+      "yellow_heart"
     ],
-    "tags": [
-      "email",
-      "envelope"
-    ]
+    "description": "yellow heart",
+    "tags": [],
+    "emoji": "💛"
   },
   {
-    "emoji": "💋",
-    "description": "kiss mark",
     "aliases": [
-      "kiss"
+      "green_heart"
     ],
+    "description": "green heart",
+    "tags": [],
+    "emoji": "💚"
+  },
+  {
+    "aliases": [
+      "nail_care"
+    ],
+    "description": "nail polish",
     "tags": [
+      "beauty",
+      "manicure"
+    ],
+    "emoji": "💅"
+  },
+  {
+    "aliases": [
       "lipstick"
-    ]
+    ],
+    "description": "lipstick",
+    "tags": [
+      "makeup"
+    ],
+    "emoji": "💄"
   },
   {
-    "emoji": "💍",
-    "description": "ring",
+    "aliases": [
+      "haircut"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "haircut",
+    "tags": [
+      "beauty"
+    ],
+    "emoji": "💇"
+  },
+  {
+    "aliases": [
+      "massage"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "face massage",
+    "tags": [
+      "spa"
+    ],
+    "emoji": "💆"
+  },
+  {
+    "aliases": [
+      "information_desk_person"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "information desk person",
+    "tags": [],
+    "emoji": "💁"
+  },
+  {
+    "aliases": [
+      "skull"
+    ],
+    "description": "skull",
+    "tags": [
+      "dead",
+      "danger",
+      "poison"
+    ],
+    "emoji": "💀"
+  },
+  {
+    "aliases": [
+      "dancer"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "dancer",
+    "tags": [
+      "dress"
+    ],
+    "emoji": "💃"
+  },
+  {
+    "aliases": [
+      "guardsman"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "guardsman",
+    "tags": [],
+    "emoji": "💂"
+  },
+  {
     "aliases": [
       "ring"
     ],
+    "description": "ring",
     "tags": [
       "wedding",
       "marriage",
       "engaged"
-    ]
+    ],
+    "emoji": "💍"
   },
   {
-    "emoji": "💎",
-    "description": "gem stone",
+    "aliases": [
+      "love_letter"
+    ],
+    "description": "love letter",
+    "tags": [
+      "email",
+      "envelope"
+    ],
+    "emoji": "💌"
+  },
+  {
+    "aliases": [
+      "couplekiss"
+    ],
+    "description": "kiss",
+    "tags": [],
+    "emoji": "💏"
+  },
+  {
     "aliases": [
       "gem"
     ],
+    "description": "gem stone",
     "tags": [
       "diamond"
-    ]
-  },
-  {
-    "emoji": "👤",
-    "description": "bust in silhouette",
-    "aliases": [
-      "bust_in_silhouette"
-    ],
-    "tags": [
-      "user"
-    ]
-  },
-  {
-    "emoji": "👥",
-    "description": "busts in silhouette",
-    "aliases": [
-      "busts_in_silhouette"
-    ],
-    "tags": [
-      "users",
-      "group",
-      "team"
-    ]
-  },
-  {
-    "emoji": "💬",
-    "description": "speech balloon",
-    "aliases": [
-      "speech_balloon"
-    ],
-    "tags": [
-      "comment"
-    ]
-  },
-  {
-    "emoji": "👣",
-    "description": "footprints",
-    "aliases": [
-      "footprints"
-    ],
-    "tags": [
-      "feet",
-      "tracks"
-    ]
-  },
-  {
-    "emoji": "💭",
-    "description": "thought balloon",
-    "aliases": [
-      "thought_balloon"
-    ],
-    "tags": [
-      "thinking"
-    ]
-  },
-  {
-    "emoji": "🐶",
-    "description": "dog face",
-    "aliases": [
-      "dog"
-    ],
-    "tags": [
-      "pet"
-    ]
-  },
-  {
-    "emoji": "🐺",
-    "description": "wolf face",
-    "aliases": [
-      "wolf"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐱",
-    "description": "cat face",
-    "aliases": [
-      "cat"
-    ],
-    "tags": [
-      "pet"
-    ]
-  },
-  {
-    "emoji": "🐭",
-    "description": "mouse face",
-    "aliases": [
-      "mouse"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐹",
-    "description": "hamster face",
-    "aliases": [
-      "hamster"
-    ],
-    "tags": [
-      "pet"
-    ]
-  },
-  {
-    "emoji": "🐰",
-    "description": "rabbit face",
-    "aliases": [
-      "rabbit"
-    ],
-    "tags": [
-      "bunny"
-    ]
-  },
-  {
-    "emoji": "🐸",
-    "description": "frog face",
-    "aliases": [
-      "frog"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐯",
-    "description": "tiger face",
-    "aliases": [
-      "tiger"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐨",
-    "description": "koala",
-    "aliases": [
-      "koala"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐻",
-    "description": "bear face",
-    "aliases": [
-      "bear"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐷",
-    "description": "pig face",
-    "aliases": [
-      "pig"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐽",
-    "description": "pig nose",
-    "aliases": [
-      "pig_nose"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐮",
-    "description": "cow face",
-    "aliases": [
-      "cow"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐗",
-    "description": "boar",
-    "aliases": [
-      "boar"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐵",
-    "description": "monkey face",
-    "aliases": [
-      "monkey_face"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐒",
-    "description": "monkey",
-    "aliases": [
-      "monkey"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐴",
-    "description": "horse face",
-    "aliases": [
-      "horse"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐑",
-    "description": "sheep",
-    "aliases": [
-      "sheep"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐘",
-    "description": "elephant",
-    "aliases": [
-      "elephant"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐼",
-    "description": "panda face",
-    "aliases": [
-      "panda_face"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐧",
-    "description": "penguin",
-    "aliases": [
-      "penguin"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐦",
-    "description": "bird",
-    "aliases": [
-      "bird"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐤",
-    "description": "baby chick",
-    "aliases": [
-      "baby_chick"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐥",
-    "description": "front-facing baby chick",
-    "aliases": [
-      "hatched_chick"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐣",
-    "description": "hatching chick",
-    "aliases": [
-      "hatching_chick"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐔",
-    "description": "chicken",
-    "aliases": [
-      "chicken"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐍",
-    "description": "snake",
-    "aliases": [
-      "snake"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐢",
-    "description": "turtle",
-    "aliases": [
-      "turtle"
-    ],
-    "tags": [
-      "slow"
-    ]
-  },
-  {
-    "emoji": "🐛",
-    "description": "bug",
-    "aliases": [
-      "bug"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐝",
-    "description": "honeybee",
-    "aliases": [
-      "bee",
-      "honeybee"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐜",
-    "description": "ant",
-    "aliases": [
-      "ant"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐞",
-    "description": "lady beetle",
-    "aliases": [
-      "beetle"
-    ],
-    "tags": [
-      "bug"
-    ]
-  },
-  {
-    "emoji": "🐌",
-    "description": "snail",
-    "aliases": [
-      "snail"
-    ],
-    "tags": [
-      "slow"
-    ]
-  },
-  {
-    "emoji": "🐙",
-    "description": "octopus",
-    "aliases": [
-      "octopus"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐚",
-    "description": "spiral shell",
-    "aliases": [
-      "shell"
-    ],
-    "tags": [
-      "sea",
-      "beach"
-    ]
-  },
-  {
-    "emoji": "🐠",
-    "description": "tropical fish",
-    "aliases": [
-      "tropical_fish"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐟",
-    "description": "fish",
-    "aliases": [
-      "fish"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐬",
-    "description": "dolphin",
-    "aliases": [
-      "dolphin",
-      "flipper"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐳",
-    "description": "spouting whale",
-    "aliases": [
-      "whale"
-    ],
-    "tags": [
-      "sea"
-    ]
-  },
-  {
-    "emoji": "🐋",
-    "description": "whale",
-    "aliases": [
-      "whale2"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐄",
-    "description": "cow",
-    "aliases": [
-      "cow2"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐏",
-    "description": "ram",
-    "aliases": [
-      "ram"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐀",
-    "description": "rat",
-    "aliases": [
-      "rat"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐃",
-    "description": "water buffalo",
-    "aliases": [
-      "water_buffalo"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐅",
-    "description": "tiger",
-    "aliases": [
-      "tiger2"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐇",
-    "description": "rabbit",
-    "aliases": [
-      "rabbit2"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐉",
-    "description": "dragon",
-    "aliases": [
-      "dragon"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐎",
-    "description": "horse",
-    "aliases": [
-      "racehorse"
-    ],
-    "tags": [
-      "speed"
-    ]
-  },
-  {
-    "emoji": "🐐",
-    "description": "goat",
-    "aliases": [
-      "goat"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐓",
-    "description": "rooster",
-    "aliases": [
-      "rooster"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐕",
-    "description": "dog",
-    "aliases": [
-      "dog2"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐖",
-    "description": "pig",
-    "aliases": [
-      "pig2"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐁",
-    "description": "mouse",
-    "aliases": [
-      "mouse2"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐂",
-    "description": "ox",
-    "aliases": [
-      "ox"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐲",
-    "description": "dragon face",
-    "aliases": [
-      "dragon_face"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐡",
-    "description": "blowfish",
-    "aliases": [
-      "blowfish"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐊",
-    "description": "crocodile",
-    "aliases": [
-      "crocodile"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐫",
-    "description": "bactrian camel",
-    "aliases": [
-      "camel"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐪",
-    "description": "dromedary camel",
-    "aliases": [
-      "dromedary_camel"
-    ],
-    "tags": [
-      "desert"
-    ]
-  },
-  {
-    "emoji": "🐆",
-    "description": "leopard",
-    "aliases": [
-      "leopard"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐈",
-    "description": "cat",
-    "aliases": [
-      "cat2"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🐩",
-    "description": "poodle",
-    "aliases": [
-      "poodle"
-    ],
-    "tags": [
-      "dog"
-    ]
-  },
-  {
-    "emoji": "🐾",
-    "description": "paw prints",
-    "aliases": [
-      "feet",
-      "paw_prints"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "💐",
-    "description": "bouquet",
-    "aliases": [
-      "bouquet"
-    ],
-    "tags": [
-      "flowers"
-    ]
-  },
-  {
-    "emoji": "🌸",
-    "description": "cherry blossom",
-    "aliases": [
-      "cherry_blossom"
-    ],
-    "tags": [
-      "flower",
-      "spring"
-    ]
-  },
-  {
-    "emoji": "🌷",
-    "description": "tulip",
-    "aliases": [
-      "tulip"
-    ],
-    "tags": [
-      "flower"
-    ]
-  },
-  {
-    "emoji": "🍀",
-    "description": "four leaf clover",
-    "aliases": [
-      "four_leaf_clover"
-    ],
-    "tags": [
-      "luck"
-    ]
-  },
-  {
-    "emoji": "🌹",
-    "description": "rose",
-    "aliases": [
-      "rose"
-    ],
-    "tags": [
-      "flower"
-    ]
-  },
-  {
-    "emoji": "🌻",
-    "description": "sunflower",
-    "aliases": [
-      "sunflower"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🌺",
-    "description": "hibiscus",
-    "aliases": [
-      "hibiscus"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍁",
-    "description": "maple leaf",
-    "aliases": [
-      "maple_leaf"
-    ],
-    "tags": [
-      "canada"
-    ]
-  },
-  {
-    "emoji": "🍃",
-    "description": "leaf fluttering in wind",
-    "aliases": [
-      "leaves"
-    ],
-    "tags": [
-      "leaf"
-    ]
-  },
-  {
-    "emoji": "🍂",
-    "description": "fallen leaf",
-    "aliases": [
-      "fallen_leaf"
-    ],
-    "tags": [
-      "autumn"
-    ]
-  },
-  {
-    "emoji": "🌿",
-    "description": "herb",
-    "aliases": [
-      "herb"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🌾",
-    "description": "ear of rice",
-    "aliases": [
-      "ear_of_rice"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍄",
-    "description": "mushroom",
-    "aliases": [
-      "mushroom"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🌵",
-    "description": "cactus",
-    "aliases": [
-      "cactus"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🌴",
-    "description": "palm tree",
-    "aliases": [
-      "palm_tree"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🌲",
-    "description": "evergreen tree",
-    "aliases": [
-      "evergreen_tree"
-    ],
-    "tags": [
-      "wood"
-    ]
-  },
-  {
-    "emoji": "🌳",
-    "description": "deciduous tree",
-    "aliases": [
-      "deciduous_tree"
-    ],
-    "tags": [
-      "wood"
-    ]
-  },
-  {
-    "emoji": "🌰",
-    "description": "chestnut",
-    "aliases": [
-      "chestnut"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🌱",
-    "description": "seedling",
-    "aliases": [
-      "seedling"
-    ],
-    "tags": [
-      "plant"
-    ]
-  },
-  {
-    "emoji": "🌼",
-    "description": "blossom",
-    "aliases": [
-      "blossom"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🌐",
-    "description": "globe with meridians",
-    "aliases": [
-      "globe_with_meridians"
-    ],
-    "tags": [
-      "world",
-      "global",
-      "international"
-    ]
-  },
-  {
-    "emoji": "🌞",
-    "description": "sun with face",
-    "aliases": [
-      "sun_with_face"
-    ],
-    "tags": [
-      "summer"
-    ]
-  },
-  {
-    "emoji": "🌝",
-    "description": "full moon with face",
-    "aliases": [
-      "full_moon_with_face"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🌚",
-    "description": "new moon with face",
-    "aliases": [
-      "new_moon_with_face"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🌑",
-    "description": "new moon symbol",
-    "aliases": [
-      "new_moon"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🌒",
-    "description": "waxing crescent moon symbol",
-    "aliases": [
-      "waxing_crescent_moon"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🌓",
-    "description": "first quarter moon symbol",
-    "aliases": [
-      "first_quarter_moon"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🌔",
-    "description": "waxing gibbous moon symbol",
-    "aliases": [
-      "moon",
-      "waxing_gibbous_moon"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🌕",
-    "description": "full moon symbol",
-    "aliases": [
-      "full_moon"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🌖",
-    "description": "waning gibbous moon symbol",
-    "aliases": [
-      "waning_gibbous_moon"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🌗",
-    "description": "last quarter moon symbol",
-    "aliases": [
-      "last_quarter_moon"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🌘",
-    "description": "waning crescent moon symbol",
-    "aliases": [
-      "waning_crescent_moon"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🌜",
-    "description": "last quarter moon with face",
-    "aliases": [
-      "last_quarter_moon_with_face"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🌛",
-    "description": "first quarter moon with face",
-    "aliases": [
-      "first_quarter_moon_with_face"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🌙",
-    "description": "crescent moon",
-    "aliases": [
-      "crescent_moon"
-    ],
-    "tags": [
-      "night"
-    ]
-  },
-  {
-    "emoji": "🌍",
-    "description": "earth globe europe-africa",
-    "aliases": [
-      "earth_africa"
-    ],
-    "tags": [
-      "globe",
-      "world",
-      "international"
-    ]
-  },
-  {
-    "emoji": "🌎",
-    "description": "earth globe americas",
-    "aliases": [
-      "earth_americas"
-    ],
-    "tags": [
-      "globe",
-      "world",
-      "international"
-    ]
-  },
-  {
-    "emoji": "🌏",
-    "description": "earth globe asia-australia",
-    "aliases": [
-      "earth_asia"
-    ],
-    "tags": [
-      "globe",
-      "world",
-      "international"
-    ]
-  },
-  {
-    "emoji": "🌋",
-    "description": "volcano",
-    "aliases": [
-      "volcano"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🌌",
-    "description": "milky way",
-    "aliases": [
-      "milky_way"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🌠",
-    "description": "shooting star",
-    "aliases": [
-      "stars"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "⭐",
-    "description": "white medium star",
-    "aliases": [
-      "star"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "☀",
-    "description": "black sun with rays",
-    "aliases": [
-      "sunny"
-    ],
-    "tags": [
-      "weather"
-    ]
-  },
-  {
-    "emoji": "⛅",
-    "description": "sun behind cloud",
-    "aliases": [
-      "partly_sunny"
-    ],
-    "tags": [
-      "weather",
-      "cloud"
-    ]
-  },
-  {
-    "emoji": "☁",
-    "description": "cloud",
-    "aliases": [
-      "cloud"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "⚡",
-    "description": "high voltage sign",
-    "aliases": [
-      "zap"
-    ],
-    "tags": [
-      "lightning",
-      "thunder"
-    ]
-  },
-  {
-    "emoji": "☔",
-    "description": "umbrella with rain drops",
-    "aliases": [
-      "umbrella"
-    ],
-    "tags": [
-      "rain",
-      "weather"
-    ]
-  },
-  {
-    "emoji": "❄",
-    "description": "snowflake",
-    "aliases": [
-      "snowflake"
-    ],
-    "tags": [
-      "winter",
-      "cold",
-      "weather"
-    ]
-  },
-  {
-    "emoji": "⛄",
-    "description": "snowman without snow",
-    "aliases": [
-      "snowman"
-    ],
-    "tags": [
-      "winter",
-      "christmas"
-    ]
-  },
-  {
-    "emoji": "🌀",
-    "description": "cyclone",
-    "aliases": [
-      "cyclone"
-    ],
-    "tags": [
-      "swirl"
-    ]
-  },
-  {
-    "emoji": "🌁",
-    "description": "foggy",
-    "aliases": [
-      "foggy"
-    ],
-    "tags": [
-      "karl"
-    ]
-  },
-  {
-    "emoji": "🌈",
-    "description": "rainbow",
-    "aliases": [
-      "rainbow"
-    ],
-    "tags": [
-      "pride"
-    ]
-  },
-  {
-    "emoji": "🌊",
-    "description": "water wave",
-    "aliases": [
-      "ocean"
-    ],
-    "tags": [
-      "sea"
-    ]
-  },
-  {
-    "emoji": "🎍",
-    "description": "pine decoration",
-    "aliases": [
-      "bamboo"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "💝",
-    "description": "heart with ribbon",
-    "aliases": [
-      "gift_heart"
-    ],
-    "tags": [
-      "chocolates"
-    ]
-  },
-  {
-    "emoji": "🎎",
-    "description": "japanese dolls",
-    "aliases": [
-      "dolls"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🎒",
-    "description": "school satchel",
-    "aliases": [
-      "school_satchel"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🎓",
-    "description": "graduation cap",
-    "aliases": [
-      "mortar_board"
-    ],
-    "tags": [
-      "education",
-      "college",
-      "university",
-      "graduation"
-    ]
-  },
-  {
-    "emoji": "🎏",
-    "description": "carp streamer",
-    "aliases": [
-      "flags"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🎆",
-    "description": "fireworks",
-    "aliases": [
-      "fireworks"
-    ],
-    "tags": [
-      "festival",
-      "celebration"
-    ]
-  },
-  {
-    "emoji": "🎇",
-    "description": "firework sparkler",
-    "aliases": [
-      "sparkler"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🎐",
-    "description": "wind chime",
-    "aliases": [
-      "wind_chime"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🎑",
-    "description": "moon viewing ceremony",
-    "aliases": [
-      "rice_scene"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🎃",
-    "description": "jack-o-lantern",
-    "aliases": [
-      "jack_o_lantern"
-    ],
-    "tags": [
-      "halloween"
-    ]
-  },
-  {
-    "emoji": "👻",
-    "description": "ghost",
-    "aliases": [
-      "ghost"
-    ],
-    "tags": [
-      "halloween"
-    ]
-  },
-  {
-    "emoji": "🎅",
-    "description": "father christmas",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "santa"
-    ],
-    "tags": [
-      "christmas"
-    ]
-  },
-  {
-    "emoji": "🎄",
-    "description": "christmas tree",
-    "aliases": [
-      "christmas_tree"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🎁",
-    "description": "wrapped present",
-    "aliases": [
-      "gift"
-    ],
-    "tags": [
-      "present",
-      "birthday",
-      "christmas"
-    ]
-  },
-  {
-    "emoji": "🎋",
-    "description": "tanabata tree",
-    "aliases": [
-      "tanabata_tree"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🎉",
-    "description": "party popper",
-    "aliases": [
-      "tada"
-    ],
-    "tags": [
-      "party"
-    ]
-  },
-  {
-    "emoji": "🎊",
-    "description": "confetti ball",
-    "aliases": [
-      "confetti_ball"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🎈",
-    "description": "balloon",
-    "aliases": [
-      "balloon"
-    ],
-    "tags": [
-      "party",
-      "birthday"
-    ]
-  },
-  {
-    "emoji": "🎌",
-    "description": "crossed flags",
-    "aliases": [
-      "crossed_flags"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔮",
-    "description": "crystal ball",
-    "aliases": [
-      "crystal_ball"
-    ],
-    "tags": [
-      "fortune"
-    ]
-  },
-  {
-    "emoji": "🎥",
-    "description": "movie camera",
-    "aliases": [
-      "movie_camera"
-    ],
-    "tags": [
-      "film",
-      "video"
-    ]
-  },
-  {
-    "emoji": "📷",
-    "description": "camera",
-    "aliases": [
-      "camera"
-    ],
-    "tags": [
-      "photo"
-    ]
-  },
-  {
-    "emoji": "📹",
-    "description": "video camera",
-    "aliases": [
-      "video_camera"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📼",
-    "description": "videocassette",
-    "aliases": [
-      "vhs"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "💿",
-    "description": "optical disc",
-    "aliases": [
-      "cd"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📀",
-    "description": "dvd",
-    "aliases": [
-      "dvd"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "💽",
-    "description": "minidisc",
-    "aliases": [
-      "minidisc"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "💾",
-    "description": "floppy disk",
-    "aliases": [
-      "floppy_disk"
-    ],
-    "tags": [
-      "save"
-    ]
-  },
-  {
-    "emoji": "💻",
-    "description": "personal computer",
-    "aliases": [
-      "computer"
-    ],
-    "tags": [
-      "desktop",
-      "screen"
-    ]
-  },
-  {
-    "emoji": "📱",
-    "description": "mobile phone",
-    "aliases": [
-      "iphone"
-    ],
-    "tags": [
-      "smartphone",
-      "mobile"
-    ]
-  },
-  {
-    "emoji": "☎",
-    "description": "black telephone",
-    "aliases": [
-      "phone",
-      "telephone"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📞",
-    "description": "telephone receiver",
-    "aliases": [
-      "telephone_receiver"
-    ],
-    "tags": [
-      "phone",
-      "call"
-    ]
-  },
-  {
-    "emoji": "📟",
-    "description": "pager",
-    "aliases": [
-      "pager"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📠",
-    "description": "fax machine",
-    "aliases": [
-      "fax"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📡",
-    "description": "satellite antenna",
-    "aliases": [
-      "satellite"
-    ],
-    "tags": [
-      "signal"
-    ]
-  },
-  {
-    "emoji": "📺",
-    "description": "television",
-    "aliases": [
-      "tv"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📻",
-    "description": "radio",
-    "aliases": [
-      "radio"
-    ],
-    "tags": [
-      "podcast"
-    ]
-  },
-  {
-    "emoji": "🔊",
-    "description": "speaker with three sound waves",
-    "aliases": [
-      "loud_sound"
-    ],
-    "tags": [
-      "volume"
-    ]
-  },
-  {
-    "emoji": "🔉",
-    "description": "speaker with one sound wave",
-    "aliases": [
-      "sound"
-    ],
-    "tags": [
-      "volume"
-    ]
-  },
-  {
-    "emoji": "🔈",
-    "description": "speaker",
-    "aliases": [
-      "speaker"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔇",
-    "description": "speaker with cancellation stroke",
-    "aliases": [
-      "mute"
-    ],
-    "tags": [
-      "sound",
-      "volume"
-    ]
-  },
-  {
-    "emoji": "🔔",
-    "description": "bell",
-    "aliases": [
-      "bell"
-    ],
-    "tags": [
-      "sound",
-      "notification"
-    ]
-  },
-  {
-    "emoji": "🔕",
-    "description": "bell with cancellation stroke",
-    "aliases": [
-      "no_bell"
-    ],
-    "tags": [
-      "volume",
-      "off"
-    ]
-  },
-  {
-    "emoji": "📢",
-    "description": "public address loudspeaker",
-    "aliases": [
-      "loudspeaker"
-    ],
-    "tags": [
-      "announcement"
-    ]
-  },
-  {
-    "emoji": "📣",
-    "description": "cheering megaphone",
-    "aliases": [
-      "mega"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "⏳",
-    "description": "hourglass with flowing sand",
-    "aliases": [
-      "hourglass_flowing_sand"
-    ],
-    "tags": [
-      "time"
-    ]
-  },
-  {
-    "emoji": "⌛",
-    "description": "hourglass",
-    "aliases": [
-      "hourglass"
-    ],
-    "tags": [
-      "time"
-    ]
-  },
-  {
-    "emoji": "⏰",
-    "description": "alarm clock",
-    "aliases": [
-      "alarm_clock"
-    ],
-    "tags": [
-      "morning"
-    ]
-  },
-  {
-    "emoji": "⌚",
-    "description": "watch",
-    "aliases": [
-      "watch"
-    ],
-    "tags": [
-      "time"
-    ]
-  },
-  {
-    "emoji": "🔓",
-    "description": "open lock",
-    "aliases": [
-      "unlock"
-    ],
-    "tags": [
-      "security"
-    ]
-  },
-  {
-    "emoji": "🔒",
-    "description": "lock",
-    "aliases": [
-      "lock"
-    ],
-    "tags": [
-      "security",
-      "private"
-    ]
-  },
-  {
-    "emoji": "🔏",
-    "description": "lock with ink pen",
-    "aliases": [
-      "lock_with_ink_pen"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔐",
-    "description": "closed lock with key",
-    "aliases": [
-      "closed_lock_with_key"
-    ],
-    "tags": [
-      "security"
-    ]
-  },
-  {
-    "emoji": "🔑",
-    "description": "key",
-    "aliases": [
-      "key"
-    ],
-    "tags": [
-      "lock",
-      "password"
-    ]
-  },
-  {
-    "emoji": "🔎",
-    "description": "right-pointing magnifying glass",
-    "aliases": [
-      "mag_right"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "💡",
-    "description": "electric light bulb",
-    "aliases": [
-      "bulb"
-    ],
-    "tags": [
-      "idea",
-      "light"
-    ]
-  },
-  {
-    "emoji": "🔦",
-    "description": "electric torch",
-    "aliases": [
-      "flashlight"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔆",
-    "description": "high brightness symbol",
-    "aliases": [
-      "high_brightness"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔅",
-    "description": "low brightness symbol",
-    "aliases": [
-      "low_brightness"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔌",
-    "description": "electric plug",
-    "aliases": [
-      "electric_plug"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔋",
-    "description": "battery",
-    "aliases": [
-      "battery"
-    ],
-    "tags": [
-      "power"
-    ]
-  },
-  {
-    "emoji": "🔍",
-    "description": "left-pointing magnifying glass",
-    "aliases": [
-      "mag"
-    ],
-    "tags": [
-      "search",
-      "zoom"
-    ]
-  },
-  {
-    "emoji": "🛁",
-    "description": "bathtub",
-    "aliases": [
-      "bathtub"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🛀",
-    "description": "bath",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "bath"
-    ],
-    "tags": [
-      "shower"
-    ]
-  },
-  {
-    "emoji": "🚿",
-    "description": "shower",
-    "aliases": [
-      "shower"
-    ],
-    "tags": [
-      "bath"
-    ]
-  },
-  {
-    "emoji": "🚽",
-    "description": "toilet",
-    "aliases": [
-      "toilet"
-    ],
-    "tags": [
-      "wc"
-    ]
-  },
-  {
-    "emoji": "🔧",
-    "description": "wrench",
-    "aliases": [
-      "wrench"
-    ],
-    "tags": [
-      "tool"
-    ]
-  },
-  {
-    "emoji": "🔩",
-    "description": "nut and bolt",
-    "aliases": [
-      "nut_and_bolt"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔨",
-    "description": "hammer",
-    "aliases": [
-      "hammer"
-    ],
-    "tags": [
-      "tool"
-    ]
-  },
-  {
-    "emoji": "🚪",
-    "description": "door",
-    "aliases": [
-      "door"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚬",
-    "description": "smoking symbol",
-    "aliases": [
-      "smoking"
-    ],
-    "tags": [
-      "cigarette"
-    ]
-  },
-  {
-    "emoji": "💣",
-    "description": "bomb",
-    "aliases": [
-      "bomb"
-    ],
-    "tags": [
-      "boom"
-    ]
-  },
-  {
-    "emoji": "🔫",
-    "description": "pistol",
-    "aliases": [
-      "gun"
-    ],
-    "tags": [
-      "shoot",
-      "weapon"
-    ]
-  },
-  {
-    "emoji": "🔪",
-    "description": "hocho",
-    "aliases": [
-      "hocho",
-      "knife"
-    ],
-    "tags": [
-      "cut",
-      "chop"
-    ]
-  },
-  {
-    "emoji": "💊",
-    "description": "pill",
-    "aliases": [
-      "pill"
     ],
-    "tags": [
-      "health",
-      "medicine"
-    ]
+    "emoji": "💎"
   },
   {
-    "emoji": "💉",
-    "description": "syringe",
     "aliases": [
       "syringe"
     ],
+    "description": "syringe",
     "tags": [
       "health",
       "hospital",
       "needle"
-    ]
-  },
-  {
-    "emoji": "💰",
-    "description": "money bag",
-    "aliases": [
-      "moneybag"
-    ],
-    "tags": [
-      "dollar",
-      "cream"
-    ]
-  },
-  {
-    "emoji": "💴",
-    "description": "banknote with yen sign",
-    "aliases": [
-      "yen"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "💵",
-    "description": "banknote with dollar sign",
-    "aliases": [
-      "dollar"
-    ],
-    "tags": [
-      "money"
-    ]
-  },
-  {
-    "emoji": "💷",
-    "description": "banknote with pound sign",
-    "aliases": [
-      "pound"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "💶",
-    "description": "banknote with euro sign",
-    "aliases": [
-      "euro"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "💳",
-    "description": "credit card",
-    "aliases": [
-      "credit_card"
-    ],
-    "tags": [
-      "subscription"
-    ]
-  },
-  {
-    "emoji": "💸",
-    "description": "money with wings",
-    "aliases": [
-      "money_with_wings"
-    ],
-    "tags": [
-      "dollar"
-    ]
-  },
-  {
-    "emoji": "📲",
-    "description": "mobile phone with rightwards arrow at left",
-    "aliases": [
-      "calling"
-    ],
-    "tags": [
-      "call",
-      "incoming"
-    ]
-  },
-  {
-    "emoji": "📧",
-    "description": "e-mail symbol",
-    "aliases": [
-      "e-mail"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📥",
-    "description": "inbox tray",
-    "aliases": [
-      "inbox_tray"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📤",
-    "description": "outbox tray",
-    "aliases": [
-      "outbox_tray"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "✉",
-    "description": "envelope",
-    "aliases": [
-      "email",
-      "envelope"
-    ],
-    "tags": [
-      "letter"
-    ]
-  },
-  {
-    "emoji": "📩",
-    "description": "envelope with downwards arrow above",
-    "aliases": [
-      "envelope_with_arrow"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📨",
-    "description": "incoming envelope",
-    "aliases": [
-      "incoming_envelope"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📯",
-    "description": "postal horn",
-    "aliases": [
-      "postal_horn"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📫",
-    "description": "closed mailbox with raised flag",
-    "aliases": [
-      "mailbox"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📪",
-    "description": "closed mailbox with lowered flag",
-    "aliases": [
-      "mailbox_closed"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📬",
-    "description": "open mailbox with raised flag",
-    "aliases": [
-      "mailbox_with_mail"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📭",
-    "description": "open mailbox with lowered flag",
-    "aliases": [
-      "mailbox_with_no_mail"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📮",
-    "description": "postbox",
-    "aliases": [
-      "postbox"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📦",
-    "description": "package",
-    "aliases": [
-      "package"
-    ],
-    "tags": [
-      "shipping"
-    ]
-  },
-  {
-    "emoji": "📝",
-    "description": "memo",
-    "aliases": [
-      "memo",
-      "pencil"
-    ],
-    "tags": [
-      "document",
-      "note"
-    ]
-  },
-  {
-    "emoji": "📄",
-    "description": "page facing up",
-    "aliases": [
-      "page_facing_up"
-    ],
-    "tags": [
-      "document"
-    ]
-  },
-  {
-    "emoji": "📃",
-    "description": "page with curl",
-    "aliases": [
-      "page_with_curl"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📑",
-    "description": "bookmark tabs",
-    "aliases": [
-      "bookmark_tabs"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📊",
-    "description": "bar chart",
-    "aliases": [
-      "bar_chart"
-    ],
-    "tags": [
-      "stats",
-      "metrics"
-    ]
-  },
-  {
-    "emoji": "📈",
-    "description": "chart with upwards trend",
-    "aliases": [
-      "chart_with_upwards_trend"
-    ],
-    "tags": [
-      "graph",
-      "metrics"
-    ]
-  },
-  {
-    "emoji": "📉",
-    "description": "chart with downwards trend",
-    "aliases": [
-      "chart_with_downwards_trend"
-    ],
-    "tags": [
-      "graph",
-      "metrics"
-    ]
-  },
-  {
-    "emoji": "📜",
-    "description": "scroll",
-    "aliases": [
-      "scroll"
-    ],
-    "tags": [
-      "document"
-    ]
-  },
-  {
-    "emoji": "📋",
-    "description": "clipboard",
-    "aliases": [
-      "clipboard"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📅",
-    "description": "calendar",
-    "aliases": [
-      "date"
-    ],
-    "tags": [
-      "calendar",
-      "schedule"
-    ]
-  },
-  {
-    "emoji": "📆",
-    "description": "tear-off calendar",
-    "aliases": [
-      "calendar"
-    ],
-    "tags": [
-      "schedule"
-    ]
-  },
-  {
-    "emoji": "📇",
-    "description": "card index",
-    "aliases": [
-      "card_index"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📁",
-    "description": "file folder",
-    "aliases": [
-      "file_folder"
-    ],
-    "tags": [
-      "directory"
-    ]
-  },
-  {
-    "emoji": "📂",
-    "description": "open file folder",
-    "aliases": [
-      "open_file_folder"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "✂",
-    "description": "black scissors",
-    "aliases": [
-      "scissors"
-    ],
-    "tags": [
-      "cut"
-    ]
-  },
-  {
-    "emoji": "📌",
-    "description": "pushpin",
-    "aliases": [
-      "pushpin"
-    ],
-    "tags": [
-      "location"
-    ]
-  },
-  {
-    "emoji": "📎",
-    "description": "paperclip",
-    "aliases": [
-      "paperclip"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "✒",
-    "description": "black nib",
-    "aliases": [
-      "black_nib"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "✏",
-    "description": "pencil",
-    "aliases": [
-      "pencil2"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📏",
-    "description": "straight ruler",
-    "aliases": [
-      "straight_ruler"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📐",
-    "description": "triangular ruler",
-    "aliases": [
-      "triangular_ruler"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📕",
-    "description": "closed book",
-    "aliases": [
-      "closed_book"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📗",
-    "description": "green book",
-    "aliases": [
-      "green_book"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📘",
-    "description": "blue book",
-    "aliases": [
-      "blue_book"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📙",
-    "description": "orange book",
-    "aliases": [
-      "orange_book"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📓",
-    "description": "notebook",
-    "aliases": [
-      "notebook"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📔",
-    "description": "notebook with decorative cover",
-    "aliases": [
-      "notebook_with_decorative_cover"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📒",
-    "description": "ledger",
-    "aliases": [
-      "ledger"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📚",
-    "description": "books",
-    "aliases": [
-      "books"
-    ],
-    "tags": [
-      "library"
-    ]
-  },
-  {
-    "emoji": "📖",
-    "description": "open book",
-    "aliases": [
-      "book",
-      "open_book"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔖",
-    "description": "bookmark",
-    "aliases": [
-      "bookmark"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📛",
-    "description": "name badge",
-    "aliases": [
-      "name_badge"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔬",
-    "description": "microscope",
-    "aliases": [
-      "microscope"
-    ],
-    "tags": [
-      "science",
-      "laboratory",
-      "investigate"
-    ]
-  },
-  {
-    "emoji": "🔭",
-    "description": "telescope",
-    "aliases": [
-      "telescope"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📰",
-    "description": "newspaper",
-    "aliases": [
-      "newspaper"
-    ],
-    "tags": [
-      "press"
-    ]
-  },
-  {
-    "emoji": "🎨",
-    "description": "artist palette",
-    "aliases": [
-      "art"
-    ],
-    "tags": [
-      "design",
-      "paint"
-    ]
-  },
-  {
-    "emoji": "🎬",
-    "description": "clapper board",
-    "aliases": [
-      "clapper"
-    ],
-    "tags": [
-      "film"
-    ]
-  },
-  {
-    "emoji": "🎤",
-    "description": "microphone",
-    "aliases": [
-      "microphone"
-    ],
-    "tags": [
-      "sing"
-    ]
-  },
-  {
-    "emoji": "🎧",
-    "description": "headphone",
-    "aliases": [
-      "headphones"
-    ],
-    "tags": [
-      "music",
-      "earphones"
-    ]
-  },
-  {
-    "emoji": "🎼",
-    "description": "musical score",
-    "aliases": [
-      "musical_score"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🎵",
-    "description": "musical note",
-    "aliases": [
-      "musical_note"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🎶",
-    "description": "multiple musical notes",
-    "aliases": [
-      "notes"
-    ],
-    "tags": [
-      "music"
-    ]
-  },
-  {
-    "emoji": "🎹",
-    "description": "musical keyboard",
-    "aliases": [
-      "musical_keyboard"
-    ],
-    "tags": [
-      "piano"
-    ]
-  },
-  {
-    "emoji": "🎻",
-    "description": "violin",
-    "aliases": [
-      "violin"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🎺",
-    "description": "trumpet",
-    "aliases": [
-      "trumpet"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🎷",
-    "description": "saxophone",
-    "aliases": [
-      "saxophone"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🎸",
-    "description": "guitar",
-    "aliases": [
-      "guitar"
-    ],
-    "tags": [
-      "rock"
-    ]
-  },
-  {
-    "emoji": "👾",
-    "description": "alien monster",
-    "aliases": [
-      "space_invader"
-    ],
-    "tags": [
-      "game",
-      "retro"
-    ]
-  },
-  {
-    "emoji": "🎮",
-    "description": "video game",
-    "aliases": [
-      "video_game"
-    ],
-    "tags": [
-      "play",
-      "controller",
-      "console"
-    ]
-  },
-  {
-    "emoji": "🃏",
-    "description": "playing card black joker",
-    "aliases": [
-      "black_joker"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🎴",
-    "description": "flower playing cards",
-    "aliases": [
-      "flower_playing_cards"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🀄",
-    "description": "mahjong tile red dragon",
-    "aliases": [
-      "mahjong"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🎲",
-    "description": "game die",
-    "aliases": [
-      "game_die"
-    ],
-    "tags": [
-      "dice",
-      "gambling"
-    ]
-  },
-  {
-    "emoji": "🎯",
-    "description": "direct hit",
-    "aliases": [
-      "dart"
-    ],
-    "tags": [
-      "target"
-    ]
-  },
-  {
-    "emoji": "🏈",
-    "description": "american football",
-    "aliases": [
-      "football"
-    ],
-    "tags": [
-      "sports"
-    ]
-  },
-  {
-    "emoji": "🏀",
-    "description": "basketball and hoop",
-    "aliases": [
-      "basketball"
-    ],
-    "tags": [
-      "sports"
-    ]
-  },
-  {
-    "emoji": "⚽",
-    "description": "soccer ball",
-    "aliases": [
-      "soccer"
-    ],
-    "tags": [
-      "sports"
-    ]
-  },
-  {
-    "emoji": "⚾",
-    "description": "baseball",
-    "aliases": [
-      "baseball"
-    ],
-    "tags": [
-      "sports"
-    ]
-  },
-  {
-    "emoji": "🎾",
-    "description": "tennis racquet and ball",
-    "aliases": [
-      "tennis"
-    ],
-    "tags": [
-      "sports"
-    ]
-  },
-  {
-    "emoji": "🎱",
-    "description": "billiards",
-    "aliases": [
-      "8ball"
-    ],
-    "tags": [
-      "pool",
-      "billiards"
-    ]
-  },
-  {
-    "emoji": "🏉",
-    "description": "rugby football",
-    "aliases": [
-      "rugby_football"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🎳",
-    "description": "bowling",
-    "aliases": [
-      "bowling"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "⛳",
-    "description": "flag in hole",
-    "aliases": [
-      "golf"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚵",
-    "description": "mountain bicyclist",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "mountain_bicyclist"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚴",
-    "description": "bicyclist",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "bicyclist"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🏁",
-    "description": "chequered flag",
-    "aliases": [
-      "checkered_flag"
-    ],
-    "tags": [
-      "milestone",
-      "finish"
-    ]
-  },
-  {
-    "emoji": "🏇",
-    "description": "horse racing",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "horse_racing"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🏆",
-    "description": "trophy",
-    "aliases": [
-      "trophy"
-    ],
-    "tags": [
-      "award",
-      "contest",
-      "winner"
-    ]
-  },
-  {
-    "emoji": "🎿",
-    "description": "ski and ski boot",
-    "aliases": [
-      "ski"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🏂",
-    "description": "snowboarder",
-    "aliases": [
-      "snowboarder"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🏊",
-    "description": "swimmer",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "swimmer"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🏄",
-    "description": "surfer",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "surfer"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🎣",
-    "description": "fishing pole and fish",
-    "aliases": [
-      "fishing_pole_and_fish"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "☕",
-    "description": "hot beverage",
-    "aliases": [
-      "coffee"
-    ],
-    "tags": [
-      "cafe",
-      "espresso"
-    ]
-  },
-  {
-    "emoji": "🍵",
-    "description": "teacup without handle",
-    "aliases": [
-      "tea"
-    ],
-    "tags": [
-      "green",
-      "breakfast"
-    ]
-  },
-  {
-    "emoji": "🍶",
-    "description": "sake bottle and cup",
-    "aliases": [
-      "sake"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍼",
-    "description": "baby bottle",
-    "aliases": [
-      "baby_bottle"
-    ],
-    "tags": [
-      "milk"
-    ]
-  },
-  {
-    "emoji": "🍺",
-    "description": "beer mug",
-    "aliases": [
-      "beer"
-    ],
-    "tags": [
-      "drink"
-    ]
-  },
-  {
-    "emoji": "🍻",
-    "description": "clinking beer mugs",
-    "aliases": [
-      "beers"
-    ],
-    "tags": [
-      "drinks"
-    ]
-  },
-  {
-    "emoji": "🍸",
-    "description": "cocktail glass",
-    "aliases": [
-      "cocktail"
-    ],
-    "tags": [
-      "drink"
-    ]
-  },
-  {
-    "emoji": "🍹",
-    "description": "tropical drink",
-    "aliases": [
-      "tropical_drink"
-    ],
-    "tags": [
-      "summer",
-      "vacation"
-    ]
-  },
-  {
-    "emoji": "🍷",
-    "description": "wine glass",
-    "aliases": [
-      "wine_glass"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍴",
-    "description": "fork and knife",
-    "aliases": [
-      "fork_and_knife"
-    ],
-    "tags": [
-      "cutlery"
-    ]
-  },
-  {
-    "emoji": "🍕",
-    "description": "slice of pizza",
-    "aliases": [
-      "pizza"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍔",
-    "description": "hamburger",
-    "aliases": [
-      "hamburger"
-    ],
-    "tags": [
-      "burger"
-    ]
-  },
-  {
-    "emoji": "🍟",
-    "description": "french fries",
-    "aliases": [
-      "fries"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍗",
-    "description": "poultry leg",
-    "aliases": [
-      "poultry_leg"
-    ],
-    "tags": [
-      "meat",
-      "chicken"
-    ]
-  },
-  {
-    "emoji": "🍖",
-    "description": "meat on bone",
-    "aliases": [
-      "meat_on_bone"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍝",
-    "description": "spaghetti",
-    "aliases": [
-      "spaghetti"
-    ],
-    "tags": [
-      "pasta"
-    ]
-  },
-  {
-    "emoji": "🍛",
-    "description": "curry and rice",
-    "aliases": [
-      "curry"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍤",
-    "description": "fried shrimp",
-    "aliases": [
-      "fried_shrimp"
-    ],
-    "tags": [
-      "tempura"
-    ]
-  },
-  {
-    "emoji": "🍱",
-    "description": "bento box",
-    "aliases": [
-      "bento"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍣",
-    "description": "sushi",
-    "aliases": [
-      "sushi"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍥",
-    "description": "fish cake with swirl design",
-    "aliases": [
-      "fish_cake"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍙",
-    "description": "rice ball",
-    "aliases": [
-      "rice_ball"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍘",
-    "description": "rice cracker",
-    "aliases": [
-      "rice_cracker"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍚",
-    "description": "cooked rice",
-    "aliases": [
-      "rice"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍜",
-    "description": "steaming bowl",
-    "aliases": [
-      "ramen"
-    ],
-    "tags": [
-      "noodle"
-    ]
-  },
-  {
-    "emoji": "🍲",
-    "description": "pot of food",
-    "aliases": [
-      "stew"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍢",
-    "description": "oden",
-    "aliases": [
-      "oden"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍡",
-    "description": "dango",
-    "aliases": [
-      "dango"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍳",
-    "description": "cooking",
-    "aliases": [
-      "egg"
-    ],
-    "tags": [
-      "breakfast"
-    ]
-  },
-  {
-    "emoji": "🍞",
-    "description": "bread",
-    "aliases": [
-      "bread"
-    ],
-    "tags": [
-      "toast"
-    ]
-  },
-  {
-    "emoji": "🍩",
-    "description": "doughnut",
-    "aliases": [
-      "doughnut"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍮",
-    "description": "custard",
-    "aliases": [
-      "custard"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍦",
-    "description": "soft ice cream",
-    "aliases": [
-      "icecream"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍨",
-    "description": "ice cream",
-    "aliases": [
-      "ice_cream"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍧",
-    "description": "shaved ice",
-    "aliases": [
-      "shaved_ice"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🎂",
-    "description": "birthday cake",
-    "aliases": [
-      "birthday"
-    ],
-    "tags": [
-      "party"
-    ]
-  },
-  {
-    "emoji": "🍰",
-    "description": "shortcake",
-    "aliases": [
-      "cake"
-    ],
-    "tags": [
-      "dessert"
-    ]
-  },
-  {
-    "emoji": "🍪",
-    "description": "cookie",
-    "aliases": [
-      "cookie"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍫",
-    "description": "chocolate bar",
-    "aliases": [
-      "chocolate_bar"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍬",
-    "description": "candy",
-    "aliases": [
-      "candy"
-    ],
-    "tags": [
-      "sweet"
-    ]
-  },
-  {
-    "emoji": "🍭",
-    "description": "lollipop",
-    "aliases": [
-      "lollipop"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍯",
-    "description": "honey pot",
-    "aliases": [
-      "honey_pot"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍎",
-    "description": "red apple",
-    "aliases": [
-      "apple"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍏",
-    "description": "green apple",
-    "aliases": [
-      "green_apple"
-    ],
-    "tags": [
-      "fruit"
-    ]
-  },
-  {
-    "emoji": "🍊",
-    "description": "tangerine",
-    "aliases": [
-      "tangerine"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍋",
-    "description": "lemon",
-    "aliases": [
-      "lemon"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍒",
-    "description": "cherries",
-    "aliases": [
-      "cherries"
-    ],
-    "tags": [
-      "fruit"
-    ]
-  },
-  {
-    "emoji": "🍇",
-    "description": "grapes",
-    "aliases": [
-      "grapes"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍉",
-    "description": "watermelon",
-    "aliases": [
-      "watermelon"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍓",
-    "description": "strawberry",
-    "aliases": [
-      "strawberry"
-    ],
-    "tags": [
-      "fruit"
-    ]
-  },
-  {
-    "emoji": "🍑",
-    "description": "peach",
-    "aliases": [
-      "peach"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍈",
-    "description": "melon",
-    "aliases": [
-      "melon"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍌",
-    "description": "banana",
-    "aliases": [
-      "banana"
-    ],
-    "tags": [
-      "fruit"
-    ]
-  },
-  {
-    "emoji": "🍐",
-    "description": "pear",
-    "aliases": [
-      "pear"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍍",
-    "description": "pineapple",
-    "aliases": [
-      "pineapple"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍠",
-    "description": "roasted sweet potato",
-    "aliases": [
-      "sweet_potato"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🍆",
-    "description": "aubergine",
-    "aliases": [
-      "eggplant"
-    ],
-    "tags": [
-      "aubergine"
-    ]
-  },
-  {
-    "emoji": "🍅",
-    "description": "tomato",
-    "aliases": [
-      "tomato"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🌽",
-    "description": "ear of maize",
-    "aliases": [
-      "corn"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🏠",
-    "description": "house building",
-    "aliases": [
-      "house"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🏡",
-    "description": "house with garden",
-    "aliases": [
-      "house_with_garden"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🏫",
-    "description": "school",
-    "aliases": [
-      "school"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🏢",
-    "description": "office building",
-    "aliases": [
-      "office"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🏣",
-    "description": "japanese post office",
-    "aliases": [
-      "post_office"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🏥",
-    "description": "hospital",
-    "aliases": [
-      "hospital"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🏦",
-    "description": "bank",
-    "aliases": [
-      "bank"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🏪",
-    "description": "convenience store",
-    "aliases": [
-      "convenience_store"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🏩",
-    "description": "love hotel",
-    "aliases": [
-      "love_hotel"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🏨",
-    "description": "hotel",
-    "aliases": [
-      "hotel"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "💒",
-    "description": "wedding",
-    "aliases": [
-      "wedding"
-    ],
-    "tags": [
-      "marriage"
-    ]
-  },
-  {
-    "emoji": "⛪",
-    "description": "church",
-    "aliases": [
-      "church"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🏬",
-    "description": "department store",
-    "aliases": [
-      "department_store"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🏤",
-    "description": "european post office",
-    "aliases": [
-      "european_post_office"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🌇",
-    "description": "sunset over buildings",
-    "aliases": [
-      "city_sunrise"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🌆",
-    "description": "cityscape at dusk",
-    "aliases": [
-      "city_sunset"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🏯",
-    "description": "japanese castle",
-    "aliases": [
-      "japanese_castle"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🏰",
-    "description": "european castle",
-    "aliases": [
-      "european_castle"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "⛺",
-    "description": "tent",
-    "aliases": [
-      "tent"
-    ],
-    "tags": [
-      "camping"
-    ]
-  },
-  {
-    "emoji": "🏭",
-    "description": "factory",
-    "aliases": [
-      "factory"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🗼",
-    "description": "tokyo tower",
-    "aliases": [
-      "tokyo_tower"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🗾",
-    "description": "silhouette of japan",
-    "aliases": [
-      "japan"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🗻",
-    "description": "mount fuji",
-    "aliases": [
-      "mount_fuji"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🌄",
-    "description": "sunrise over mountains",
-    "aliases": [
-      "sunrise_over_mountains"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🌅",
-    "description": "sunrise",
-    "aliases": [
-      "sunrise"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🌃",
-    "description": "night with stars",
-    "aliases": [
-      "night_with_stars"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🗽",
-    "description": "statue of liberty",
-    "aliases": [
-      "statue_of_liberty"
     ],
-    "tags": [
-    ]
+    "emoji": "💉"
   },
   {
-    "emoji": "🌉",
-    "description": "bridge at night",
     "aliases": [
       "bridge_at_night"
     ],
-    "tags": [
-    ]
+    "description": "bridge at night",
+    "tags": [],
+    "emoji": "🌉"
   },
   {
-    "emoji": "🎠",
-    "description": "carousel horse",
     "aliases": [
-      "carousel_horse"
+      "kiss"
     ],
+    "description": "kiss mark",
     "tags": [
-    ]
+      "lipstick"
+    ],
+    "emoji": "💋"
   },
   {
-    "emoji": "🎡",
-    "description": "ferris wheel",
     "aliases": [
-      "ferris_wheel"
+      "pill"
     ],
+    "description": "pill",
     "tags": [
-    ]
+      "health",
+      "medicine"
+    ],
+    "emoji": "💊"
   },
   {
-    "emoji": "⛲",
-    "description": "fountain",
     "aliases": [
-      "fountain"
+      "detective",
+      "sleuth",
+      "sleuth_or_spy",
+      "private_eye",
+      "spy"
     ],
-    "tags": [
-    ]
+    "supports_fitzpatrick": false,
+    "description": "sleuth or spy",
+    "tags": [],
+    "emoji": "🕵"
   },
   {
-    "emoji": "🎢",
-    "description": "roller coaster",
     "aliases": [
-      "roller_coaster"
+      "man_in_business_suit_levitating",
+      "hovering_man",
+      "levitating_man"
     ],
-    "tags": [
-    ]
+    "supports_fitzpatrick": false,
+    "description": "man in business suit levitating",
+    "tags": [],
+    "emoji": "🕴"
   },
   {
-    "emoji": "🚢",
-    "description": "ship",
     "aliases": [
-      "ship"
+      "spider"
     ],
-    "tags": [
-    ]
+    "supports_fitzpatrick": false,
+    "description": "black spider with eight legs",
+    "tags": [],
+    "emoji": "🕷"
   },
   {
-    "emoji": "⛵",
-    "description": "sailboat",
     "aliases": [
-      "boat",
-      "sailboat"
+      "kz",
+      "flag-kz"
     ],
+    "emoji": "🇰🇿",
+    "description": "regional indicator symbol letter k + regional indicator symbol letter z",
     "tags": [
+      "flag",
+      "kazakhstan"
     ]
   },
   {
-    "emoji": "🚤",
-    "description": "speedboat",
-    "aliases": [
-      "speedboat"
-    ],
-    "tags": [
-      "ship"
-    ]
-  },
-  {
-    "emoji": "🚣",
-    "description": "rowboat",
     "aliases": [
       "rowboat"
     ],
-    "tags": [
-    ]
+    "description": "rowboat",
+    "tags": [],
+    "emoji": "🚣"
   },
   {
-    "emoji": "⚓",
-    "description": "anchor",
     "aliases": [
-      "anchor"
+      "hole"
     ],
-    "tags": [
+    "supports_fitzpatrick": false,
+    "description": "hole",
+    "tags": [],
+    "emoji": "🕳"
+  },
+  {
+    "aliases": [
+      "vs"
+    ],
+    "description": "squared vs",
+    "tags": [],
+    "emoji": "🆚"
+  },
+  {
+    "aliases": [
       "ship"
-    ]
-  },
-  {
-    "emoji": "🚀",
-    "description": "rocket",
-    "aliases": [
-      "rocket"
     ],
-    "tags": [
-      "ship",
-      "launch"
-    ]
+    "description": "ship",
+    "tags": [],
+    "emoji": "🚢"
   },
   {
-    "emoji": "✈",
-    "description": "airplane",
-    "aliases": [
-      "airplane"
-    ],
-    "tags": [
-      "flight"
-    ]
-  },
-  {
-    "emoji": "💺",
-    "description": "seat",
-    "aliases": [
-      "seat"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚁",
-    "description": "helicopter",
-    "aliases": [
-      "helicopter"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚂",
-    "description": "steam locomotive",
-    "aliases": [
-      "steam_locomotive"
-    ],
-    "tags": [
-      "train"
-    ]
-  },
-  {
-    "emoji": "🚊",
-    "description": "tram",
-    "aliases": [
-      "tram"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚉",
-    "description": "station",
-    "aliases": [
-      "station"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚞",
-    "description": "mountain railway",
-    "aliases": [
-      "mountain_railway"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚆",
-    "description": "train",
-    "aliases": [
-      "train2"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚄",
-    "description": "high-speed train",
-    "aliases": [
-      "bullettrain_side"
-    ],
-    "tags": [
-      "train"
-    ]
-  },
-  {
-    "emoji": "🚅",
-    "description": "high-speed train with bullet nose",
-    "aliases": [
-      "bullettrain_front"
-    ],
-    "tags": [
-      "train"
-    ]
-  },
-  {
-    "emoji": "🚈",
-    "description": "light rail",
-    "aliases": [
-      "light_rail"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚇",
-    "description": "metro",
-    "aliases": [
-      "metro"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚝",
-    "description": "monorail",
-    "aliases": [
-      "monorail"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚋",
-    "description": "tram car",
-    "aliases": [
-      "train"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚃",
-    "description": "railway car",
-    "aliases": [
-      "railway_car"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚎",
-    "description": "trolleybus",
-    "aliases": [
-      "trolleybus"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚌",
-    "description": "bus",
-    "aliases": [
-      "bus"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚍",
-    "description": "oncoming bus",
-    "aliases": [
-      "oncoming_bus"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚙",
-    "description": "recreational vehicle",
     "aliases": [
       "blue_car"
     ],
-    "tags": [
-    ]
+    "description": "recreational vehicle",
+    "tags": [],
+    "emoji": "🚙"
   },
   {
-    "emoji": "🚘",
-    "description": "oncoming automobile",
     "aliases": [
-      "oncoming_automobile"
+      "cobweb",
+      "spider_web"
     ],
+    "supports_fitzpatrick": false,
+    "description": "spider web in orb form",
+    "tags": [],
+    "emoji": "🕸"
+  },
+  {
+    "aliases": [
+      "flag-ba",
+      "ba"
+    ],
+    "emoji": "🇧🇦",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter a",
     "tags": [
+      "flag",
+      "bosnia and herzegovina"
     ]
   },
   {
-    "emoji": "🚗",
-    "description": "automobile",
+    "aliases": [
+      "clock1030"
+    ],
+    "description": "clock face ten-thirty",
+    "tags": [],
+    "emoji": "🕥"
+  },
+  {
+    "aliases": [
+      "no_smoking"
+    ],
+    "description": "no smoking symbol",
+    "tags": [],
+    "emoji": "🚭"
+  },
+  {
+    "aliases": [
+      "clock1230"
+    ],
+    "description": "clock face twelve-thirty",
+    "tags": [],
+    "emoji": "🕧"
+  },
+  {
+    "aliases": [
+      "clock1130"
+    ],
+    "description": "clock face eleven-thirty",
+    "tags": [],
+    "emoji": "🕦"
+  },
+  {
+    "aliases": [
+      "clock630"
+    ],
+    "description": "clock face six-thirty",
+    "tags": [],
+    "emoji": "🕡"
+  },
+  {
+    "aliases": [
+      "new"
+    ],
+    "description": "squared new",
+    "tags": [
+      "fresh"
+    ],
+    "emoji": "🆕"
+  },
+  {
+    "aliases": [
+      "clock830"
+    ],
+    "description": "clock face eight-thirty",
+    "tags": [],
+    "emoji": "🕣"
+  },
+  {
+    "aliases": [
+      "honey_pot"
+    ],
+    "description": "honey pot",
+    "tags": [],
+    "emoji": "🍯"
+  },
+  {
+    "aliases": [
+      "candle"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "candle burning",
+    "tags": [],
+    "emoji": "🕯"
+  },
+  {
+    "aliases": [
+      "up"
+    ],
+    "description": "squared up with exclamation mark",
+    "tags": [],
+    "emoji": "🆙"
+  },
+  {
+    "aliases": [
+      "do_not_litter"
+    ],
+    "description": "do not litter symbol",
+    "tags": [],
+    "emoji": "🚯"
+  },
+  {
+    "aliases": [
+      "heavy_plus_sign"
+    ],
+    "description": "heavy plus sign",
+    "tags": [],
+    "emoji": "➕"
+  },
+  {
+    "aliases": [
+      "clock6"
+    ],
+    "description": "clock face six oclock",
+    "tags": [],
+    "emoji": "🕕"
+  },
+  {
+    "aliases": [
+      "clock5"
+    ],
+    "description": "clock face five oclock",
+    "tags": [],
+    "emoji": "🕔"
+  },
+  {
+    "aliases": [
+      "clock8"
+    ],
+    "description": "clock face eight oclock",
+    "tags": [],
+    "emoji": "🕗"
+  },
+  {
+    "aliases": [
+      "put_litter_in_its_place"
+    ],
+    "description": "put litter in its place symbol",
+    "tags": [],
+    "emoji": "🚮"
+  },
+  {
+    "aliases": [
+      "clock2"
+    ],
+    "description": "clock face two oclock",
+    "tags": [],
+    "emoji": "🕑"
+  },
+  {
+    "aliases": [
+      "clock1"
+    ],
+    "description": "clock face one oclock",
+    "tags": [],
+    "emoji": "🕐"
+  },
+  {
+    "aliases": [
+      "clock4"
+    ],
+    "description": "clock face four oclock",
+    "tags": [],
+    "emoji": "🕓"
+  },
+  {
+    "aliases": [
+      "congratulations"
+    ],
+    "description": "circled ideograph congratulation",
+    "tags": [],
+    "emoji": "㊗"
+  },
+  {
+    "aliases": [
+      "clock230"
+    ],
+    "description": "clock face two-thirty",
+    "tags": [],
+    "emoji": "🕝"
+  },
+  {
+    "aliases": [
+      "triangular_flag_on_post"
+    ],
+    "description": "triangular flag on post",
+    "tags": [],
+    "emoji": "🚩"
+  },
+  {
+    "aliases": [
+      "clock430"
+    ],
+    "description": "clock face four-thirty",
+    "tags": [],
+    "emoji": "🕟"
+  },
+  {
+    "aliases": [
+      "clock330"
+    ],
+    "description": "clock face three-thirty",
+    "tags": [],
+    "emoji": "🕞"
+  },
+  {
+    "aliases": [
+      "clock10"
+    ],
+    "description": "clock face ten oclock",
+    "tags": [],
+    "emoji": "🕙"
+  },
+  {
+    "aliases": [
+      "clock9"
+    ],
+    "description": "clock face nine oclock",
+    "tags": [],
+    "emoji": "🕘"
+  },
+  {
+    "aliases": [
+      "clock12"
+    ],
+    "description": "clock face twelve oclock",
+    "tags": [],
+    "emoji": "🕛"
+  },
+  {
+    "aliases": [
+      "rotating_light"
+    ],
+    "description": "police cars revolving light",
+    "tags": [
+      "911",
+      "emergency"
+    ],
+    "emoji": "🚨"
+  },
+  {
+    "aliases": [
+      "cool"
+    ],
+    "description": "squared cool",
+    "tags": [],
+    "emoji": "🆒"
+  },
+  {
+    "aliases": [
+      "regional_indicator_symbol_h"
+    ],
+    "emoji": "🇭",
+    "description": "regional indicator symbol letter h",
+    "tags": [
+      "letter",
+      "h"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-bs",
+      "bs"
+    ],
+    "emoji": "🇧🇸",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter s",
+    "tags": [
+      "flag",
+      "bahamas"
+    ]
+  },
+  {
+    "aliases": [
+      "speedboat"
+    ],
+    "description": "speedboat",
+    "tags": [
+      "ship"
+    ],
+    "emoji": "🚤"
+  },
+  {
+    "aliases": [
+      "jewish",
+      "synagogue",
+      "temple"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "synagogue with star of David",
+    "tags": [],
+    "emoji": "🕍"
+  },
+  {
+    "aliases": [
+      "eye"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "eye",
+    "tags": [],
+    "emoji": "👁"
+  },
+  {
+    "aliases": [
+      "wine_glass"
+    ],
+    "description": "wine glass",
+    "tags": [],
+    "emoji": "🍷"
+  },
+  {
+    "aliases": [
+      "relaxed"
+    ],
+    "description": "white smiling face",
+    "tags": [
+      "blush",
+      "pleased"
+    ],
+    "emoji": "☺"
+  },
+  {
+    "aliases": [
+      "omkara",
+      "om_symbol",
+      "pranava",
+      "aumkara"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "om symbol",
+    "tags": [],
+    "emoji": "🕉"
+  },
+  {
+    "aliases": [
+      "nine"
+    ],
+    "description": "digit nine + combining enclosing keycap",
+    "tags": [],
+    "emoji": "9⃣"
+  },
+  {
+    "aliases": [
+      "loop"
+    ],
+    "description": "double curly loop",
+    "tags": [],
+    "emoji": "➿"
+  },
+  {
+    "aliases": [
+      "flag-by",
+      "by"
+    ],
+    "emoji": "🇧🇾",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter y",
+    "tags": [
+      "flag",
+      "belarus"
+    ]
+  },
+  {
+    "aliases": [
+      "large_blue_circle"
+    ],
+    "description": "large blue circle",
+    "tags": [],
+    "emoji": "🔵"
+  },
+  {
+    "aliases": [
+      "taxi"
+    ],
+    "description": "taxi",
+    "tags": [],
+    "emoji": "🚕"
+  },
+  {
+    "aliases": [
+      "large_blue_diamond"
+    ],
+    "description": "large blue diamond",
+    "tags": [],
+    "emoji": "🔷"
+  },
+  {
+    "aliases": [
+      "large_orange_diamond"
+    ],
+    "description": "large orange diamond",
+    "tags": [],
+    "emoji": "🔶"
+  },
+  {
+    "aliases": [
+      "partly_sunny"
+    ],
+    "description": "sun behind cloud",
+    "tags": [
+      "weather",
+      "cloud"
+    ],
+    "emoji": "⛅"
+  },
+  {
+    "aliases": [
+      "snowflake"
+    ],
+    "description": "snowflake",
+    "tags": [
+      "winter",
+      "cold",
+      "weather"
+    ],
+    "emoji": "❄"
+  },
+  {
+    "aliases": [
+      "white_square_button"
+    ],
+    "description": "white square button",
+    "tags": [],
+    "emoji": "🔳"
+  },
+  {
+    "aliases": [
+      "oncoming_police_car"
+    ],
+    "description": "oncoming police car",
+    "tags": [],
+    "emoji": "🚔"
+  },
+  {
+    "aliases": [
+      "arrow_down_small"
+    ],
+    "description": "down-pointing small red triangle",
+    "tags": [],
+    "emoji": "🔽"
+  },
+  {
+    "aliases": [
+      "arrow_up_small"
+    ],
+    "description": "up-pointing small red triangle",
+    "tags": [],
+    "emoji": "🔼"
+  },
+  {
+    "aliases": [
+      "gemini"
+    ],
+    "description": "gemini",
+    "tags": [],
+    "emoji": "♊"
+  },
+  {
+    "aliases": [
+      "small_blue_diamond"
+    ],
+    "description": "small blue diamond",
+    "tags": [],
+    "emoji": "🔹"
+  },
+  {
     "aliases": [
       "car",
       "red_car"
     ],
-    "tags": [
-    ]
+    "description": "automobile",
+    "tags": [],
+    "emoji": "🚗"
   },
   {
-    "emoji": "🚕",
-    "description": "taxi",
-    "aliases": [
-      "taxi"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚖",
-    "description": "oncoming taxi",
-    "aliases": [
-      "oncoming_taxi"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚛",
-    "description": "articulated lorry",
-    "aliases": [
-      "articulated_lorry"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚚",
-    "description": "delivery truck",
-    "aliases": [
-      "truck"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚨",
-    "description": "police cars revolving light",
-    "aliases": [
-      "rotating_light"
-    ],
-    "tags": [
-      "911",
-      "emergency"
-    ]
-  },
-  {
-    "emoji": "🚓",
-    "description": "police car",
-    "aliases": [
-      "police_car"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚔",
-    "description": "oncoming police car",
-    "aliases": [
-      "oncoming_police_car"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚒",
-    "description": "fire engine",
-    "aliases": [
-      "fire_engine"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚑",
-    "description": "ambulance",
-    "aliases": [
-      "ambulance"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚐",
-    "description": "minibus",
-    "aliases": [
-      "minibus"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚲",
-    "description": "bicycle",
-    "aliases": [
-      "bike"
-    ],
-    "tags": [
-      "bicycle"
-    ]
-  },
-  {
-    "emoji": "🚡",
-    "description": "aerial tramway",
-    "aliases": [
-      "aerial_tramway"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚟",
-    "description": "suspension railway",
-    "aliases": [
-      "suspension_railway"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚠",
-    "description": "mountain cableway",
-    "aliases": [
-      "mountain_cableway"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚜",
-    "description": "tractor",
-    "aliases": [
-      "tractor"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "💈",
-    "description": "barber pole",
-    "aliases": [
-      "barber"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚏",
-    "description": "bus stop",
-    "aliases": [
-      "busstop"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🎫",
-    "description": "ticket",
-    "aliases": [
-      "ticket"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚦",
-    "description": "vertical traffic light",
-    "aliases": [
-      "vertical_traffic_light"
-    ],
-    "tags": [
-      "semaphore"
-    ]
-  },
-  {
-    "emoji": "🚥",
-    "description": "horizontal traffic light",
-    "aliases": [
-      "traffic_light"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "⚠",
-    "description": "warning sign",
-    "aliases": [
-      "warning"
-    ],
-    "tags": [
-      "wip"
-    ]
-  },
-  {
-    "emoji": "🚧",
-    "description": "construction sign",
-    "aliases": [
-      "construction"
-    ],
-    "tags": [
-      "wip"
-    ]
-  },
-  {
-    "emoji": "🔰",
-    "description": "japanese symbol for beginner",
-    "aliases": [
-      "beginner"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "⛽",
-    "description": "fuel pump",
-    "aliases": [
-      "fuelpump"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🏮",
-    "description": "izakaya lantern",
-    "aliases": [
-      "izakaya_lantern",
-      "lantern"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🎰",
-    "description": "slot machine",
-    "aliases": [
-      "slot_machine"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "♨",
-    "description": "hot springs",
-    "aliases": [
-      "hotsprings"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🗿",
-    "description": "moyai",
-    "aliases": [
-      "moyai"
-    ],
-    "tags": [
-      "stone"
-    ]
-  },
-  {
-    "emoji": "🎪",
-    "description": "circus tent",
-    "aliases": [
-      "circus_tent"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🎭",
-    "description": "performing arts",
-    "aliases": [
-      "performing_arts"
-    ],
-    "tags": [
-      "theater",
-      "drama"
-    ]
-  },
-  {
-    "emoji": "📍",
-    "description": "round pushpin",
-    "aliases": [
-      "round_pushpin"
-    ],
-    "tags": [
-      "location"
-    ]
-  },
-  {
-    "emoji": "🚩",
-    "description": "triangular flag on post",
-    "aliases": [
-      "triangular_flag_on_post"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "1⃣",
-    "description": "digit one + combining enclosing keycap",
-    "aliases": [
-      "one"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "2⃣",
-    "description": "digit two + combining enclosing keycap",
-    "aliases": [
-      "two"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "3⃣",
-    "description": "digit three + combining enclosing keycap",
-    "aliases": [
-      "three"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "4⃣",
-    "description": "digit four + combining enclosing keycap",
-    "aliases": [
-      "four"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "5⃣",
-    "description": "digit five + combining enclosing keycap",
-    "aliases": [
-      "five"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "6⃣",
-    "description": "digit six + combining enclosing keycap",
-    "aliases": [
-      "six"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "7⃣",
-    "description": "digit seven + combining enclosing keycap",
-    "aliases": [
-      "seven"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "8⃣",
-    "description": "digit eight + combining enclosing keycap",
-    "aliases": [
-      "eight"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "9⃣",
-    "description": "digit nine + combining enclosing keycap",
-    "aliases": [
-      "nine"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "0⃣",
-    "description": "digit zero + combining enclosing keycap",
-    "aliases": [
-      "zero"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔟",
-    "description": "keycap ten",
-    "aliases": [
-      "keycap_ten"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔢",
-    "description": "input symbol for numbers",
-    "aliases": [
-      "1234"
-    ],
-    "tags": [
-      "numbers"
-    ]
-  },
-  {
-    "emoji": "#⃣",
-    "description": "number sign + combining enclosing keycap",
-    "aliases": [
-      "hash"
-    ],
-    "tags": [
-      "number"
-    ]
-  },
-  {
-    "emoji": "🔣",
-    "description": "input symbol for symbols",
-    "aliases": [
-      "symbols"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "⬆",
-    "description": "upwards black arrow",
-    "aliases": [
-      "arrow_up"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "⬇",
-    "description": "downwards black arrow",
-    "aliases": [
-      "arrow_down"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "⬅",
-    "description": "leftwards black arrow",
-    "aliases": [
-      "arrow_left"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "➡",
-    "description": "black rightwards arrow",
-    "aliases": [
-      "arrow_right"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔠",
-    "description": "input symbol for latin capital letters",
-    "aliases": [
-      "capital_abcd"
-    ],
-    "tags": [
-      "letters"
-    ]
-  },
-  {
-    "emoji": "🔡",
-    "description": "input symbol for latin small letters",
-    "aliases": [
-      "abcd"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔤",
-    "description": "input symbol for latin letters",
-    "aliases": [
-      "abc"
-    ],
-    "tags": [
-      "alphabet"
-    ]
-  },
-  {
-    "emoji": "↗",
-    "description": "north east arrow",
-    "aliases": [
-      "arrow_upper_right"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "↖",
-    "description": "north west arrow",
-    "aliases": [
-      "arrow_upper_left"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "↘",
-    "description": "south east arrow",
-    "aliases": [
-      "arrow_lower_right"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "↙",
-    "description": "south west arrow",
-    "aliases": [
-      "arrow_lower_left"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "↔",
-    "description": "left right arrow",
-    "aliases": [
-      "left_right_arrow"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "↕",
-    "description": "up down arrow",
-    "aliases": [
-      "arrow_up_down"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔄",
-    "description": "anticlockwise downwards and upwards open circle arrows",
-    "aliases": [
-      "arrows_counterclockwise"
-    ],
-    "tags": [
-      "sync"
-    ]
-  },
-  {
-    "emoji": "◀",
-    "description": "black left-pointing triangle",
-    "aliases": [
-      "arrow_backward"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "▶",
-    "description": "black right-pointing triangle",
-    "aliases": [
-      "arrow_forward"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔼",
-    "description": "up-pointing small red triangle",
-    "aliases": [
-      "arrow_up_small"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔽",
-    "description": "down-pointing small red triangle",
-    "aliases": [
-      "arrow_down_small"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "↩",
-    "description": "leftwards arrow with hook",
-    "aliases": [
-      "leftwards_arrow_with_hook"
-    ],
-    "tags": [
-      "return"
-    ]
-  },
-  {
-    "emoji": "↪",
-    "description": "rightwards arrow with hook",
-    "aliases": [
-      "arrow_right_hook"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "ℹ",
-    "description": "information source",
-    "aliases": [
-      "information_source"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "⏪",
-    "description": "black left-pointing double triangle",
-    "aliases": [
-      "rewind"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "⏩",
-    "description": "black right-pointing double triangle",
-    "aliases": [
-      "fast_forward"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "⏫",
-    "description": "black up-pointing double triangle",
-    "aliases": [
-      "arrow_double_up"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "⏬",
-    "description": "black down-pointing double triangle",
-    "aliases": [
-      "arrow_double_down"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "⤵",
-    "description": "arrow pointing rightwards then curving downwards",
-    "aliases": [
-      "arrow_heading_down"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "⤴",
-    "description": "arrow pointing rightwards then curving upwards",
-    "aliases": [
-      "arrow_heading_up"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🆗",
-    "description": "squared ok",
-    "aliases": [
-      "ok"
-    ],
-    "tags": [
-      "yes"
-    ]
-  },
-  {
-    "emoji": "🔀",
-    "description": "twisted rightwards arrows",
-    "aliases": [
-      "twisted_rightwards_arrows"
-    ],
-    "tags": [
-      "shuffle"
-    ]
-  },
-  {
-    "emoji": "🔁",
-    "description": "clockwise rightwards and leftwards open circle arrows",
-    "aliases": [
-      "repeat"
-    ],
-    "tags": [
-      "loop"
-    ]
-  },
-  {
-    "emoji": "🔂",
-    "description": "clockwise rightwards and leftwards open circle arrows with circled one overlay",
-    "aliases": [
-      "repeat_one"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🆕",
-    "description": "squared new",
-    "aliases": [
-      "new"
-    ],
-    "tags": [
-      "fresh"
-    ]
-  },
-  {
-    "emoji": "🆙",
-    "description": "squared up with exclamation mark",
-    "aliases": [
-      "up"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🆒",
-    "description": "squared cool",
-    "aliases": [
-      "cool"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🆓",
-    "description": "squared free",
-    "aliases": [
-      "free"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🆖",
-    "description": "squared ng",
-    "aliases": [
-      "ng"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📶",
-    "description": "antenna with bars",
-    "aliases": [
-      "signal_strength"
-    ],
-    "tags": [
-      "wifi"
-    ]
-  },
-  {
-    "emoji": "🎦",
-    "description": "cinema",
-    "aliases": [
-      "cinema"
-    ],
-    "tags": [
-      "film",
-      "movie"
-    ]
-  },
-  {
-    "emoji": "🈁",
-    "description": "squared katakana koko",
-    "aliases": [
-      "koko"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🈯",
-    "description": "squared cjk unified ideograph-6307",
-    "aliases": [
-      "u6307"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🈳",
-    "description": "squared cjk unified ideograph-7a7a",
-    "aliases": [
-      "u7a7a"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🈵",
-    "description": "squared cjk unified ideograph-6e80",
-    "aliases": [
-      "u6e80"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🈴",
-    "description": "squared cjk unified ideograph-5408",
-    "aliases": [
-      "u5408"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🈲",
-    "description": "squared cjk unified ideograph-7981",
-    "aliases": [
-      "u7981"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🉐",
-    "description": "circled ideograph advantage",
-    "aliases": [
-      "ideograph_advantage"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🈹",
-    "description": "squared cjk unified ideograph-5272",
-    "aliases": [
-      "u5272"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🈺",
-    "description": "squared cjk unified ideograph-55b6",
-    "aliases": [
-      "u55b6"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🈶",
-    "description": "squared cjk unified ideograph-6709",
-    "aliases": [
-      "u6709"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🈚",
-    "description": "squared cjk unified ideograph-7121",
-    "aliases": [
-      "u7121"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚻",
-    "description": "restroom",
-    "aliases": [
-      "restroom"
-    ],
-    "tags": [
-      "toilet"
-    ]
-  },
-  {
-    "emoji": "🚹",
-    "description": "mens symbol",
-    "aliases": [
-      "mens"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚺",
-    "description": "womens symbol",
-    "aliases": [
-      "womens"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚼",
-    "description": "baby symbol",
-    "aliases": [
-      "baby_symbol"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚾",
-    "description": "water closet",
-    "aliases": [
-      "wc"
-    ],
-    "tags": [
-      "toilet",
-      "restroom"
-    ]
-  },
-  {
-    "emoji": "🚰",
-    "description": "potable water symbol",
-    "aliases": [
-      "potable_water"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚮",
-    "description": "put litter in its place symbol",
-    "aliases": [
-      "put_litter_in_its_place"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🅿",
-    "description": "negative squared latin capital letter p",
-    "aliases": [
-      "parking"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "♿",
-    "description": "wheelchair symbol",
-    "aliases": [
-      "wheelchair"
-    ],
-    "tags": [
-      "accessibility"
-    ]
-  },
-  {
-    "emoji": "🚭",
-    "description": "no smoking symbol",
-    "aliases": [
-      "no_smoking"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🈷",
-    "description": "squared cjk unified ideograph-6708",
-    "aliases": [
-      "u6708"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🈸",
-    "description": "squared cjk unified ideograph-7533",
-    "aliases": [
-      "u7533"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🈂",
-    "description": "squared katakana sa",
-    "aliases": [
-      "sa"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "Ⓜ",
-    "description": "circled latin capital letter m",
-    "aliases": [
-      "m"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🛂",
-    "description": "passport control",
-    "aliases": [
-      "passport_control"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🛄",
-    "description": "baggage claim",
-    "aliases": [
-      "baggage_claim"
-    ],
-    "tags": [
-      "airport"
-    ]
-  },
-  {
-    "emoji": "🛅",
-    "description": "left luggage",
-    "aliases": [
-      "left_luggage"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🛃",
-    "description": "customs",
-    "aliases": [
-      "customs"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🉑",
-    "description": "circled ideograph accept",
-    "aliases": [
-      "accept"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "㊙",
-    "description": "circled ideograph secret",
-    "aliases": [
-      "secret"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "㊗",
-    "description": "circled ideograph congratulation",
-    "aliases": [
-      "congratulations"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🆑",
-    "description": "squared cl",
-    "aliases": [
-      "cl"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🆘",
-    "description": "squared sos",
-    "aliases": [
-      "sos"
-    ],
-    "tags": [
-      "help",
-      "emergency"
-    ]
-  },
-  {
-    "emoji": "🆔",
-    "description": "squared id",
-    "aliases": [
-      "id"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚫",
-    "description": "no entry sign",
-    "aliases": [
-      "no_entry_sign"
-    ],
-    "tags": [
-      "block",
-      "forbidden"
-    ]
-  },
-  {
-    "emoji": "🔞",
-    "description": "no one under eighteen symbol",
-    "aliases": [
-      "underage"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📵",
-    "description": "no mobile phones",
-    "aliases": [
-      "no_mobile_phones"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚯",
-    "description": "do not litter symbol",
-    "aliases": [
-      "do_not_litter"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚱",
-    "description": "non-potable water symbol",
-    "aliases": [
-      "non-potable_water"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚳",
-    "description": "no bicycles",
-    "aliases": [
-      "no_bicycles"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚷",
-    "description": "no pedestrians",
-    "aliases": [
-      "no_pedestrians"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🚸",
-    "description": "children crossing",
-    "aliases": [
-      "children_crossing"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "⛔",
-    "description": "no entry",
-    "aliases": [
-      "no_entry"
-    ],
-    "tags": [
-      "limit"
-    ]
-  },
-  {
-    "emoji": "✳",
-    "description": "eight spoked asterisk",
-    "aliases": [
-      "eight_spoked_asterisk"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "❇",
-    "description": "sparkle",
-    "aliases": [
-      "sparkle"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "❎",
-    "description": "negative squared cross mark",
-    "aliases": [
-      "negative_squared_cross_mark"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "✅",
-    "description": "white heavy check mark",
-    "aliases": [
-      "white_check_mark"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "✴",
-    "description": "eight pointed black star",
-    "aliases": [
-      "eight_pointed_black_star"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "💟",
-    "description": "heart decoration",
-    "aliases": [
-      "heart_decoration"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🆚",
-    "description": "squared vs",
-    "aliases": [
-      "vs"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📳",
-    "description": "vibration mode",
-    "aliases": [
-      "vibration_mode"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "📴",
-    "description": "mobile phone off",
-    "aliases": [
-      "mobile_phone_off"
-    ],
-    "tags": [
-      "mute",
-      "off"
-    ]
-  },
-  {
-    "emoji": "🅰",
-    "description": "negative squared latin capital letter a",
-    "aliases": [
-      "a"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🅱",
-    "description": "negative squared latin capital letter b",
-    "aliases": [
-      "b"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🆎",
-    "description": "negative squared ab",
-    "aliases": [
-      "ab"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🅾",
-    "description": "negative squared latin capital letter o",
-    "aliases": [
-      "o2"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "💠",
-    "description": "diamond shape with a dot inside",
-    "aliases": [
-      "diamond_shape_with_a_dot_inside"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "➿",
-    "description": "double curly loop",
-    "aliases": [
-      "loop"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "♻",
-    "description": "black universal recycling symbol",
-    "aliases": [
-      "recycle"
-    ],
-    "tags": [
-      "environment",
-      "green"
-    ]
-  },
-  {
-    "emoji": "♈",
-    "description": "aries",
-    "aliases": [
-      "aries"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "♉",
-    "description": "taurus",
-    "aliases": [
-      "taurus"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "♊",
-    "description": "gemini",
-    "aliases": [
-      "gemini"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "♋",
-    "description": "cancer",
-    "aliases": [
-      "cancer"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "♌",
-    "description": "leo",
-    "aliases": [
-      "leo"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "♍",
-    "description": "virgo",
-    "aliases": [
-      "virgo"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "♎",
-    "description": "libra",
-    "aliases": [
-      "libra"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "♏",
-    "description": "scorpius",
-    "aliases": [
-      "scorpius"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "♐",
-    "description": "sagittarius",
-    "aliases": [
-      "sagittarius"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "♑",
-    "description": "capricorn",
-    "aliases": [
-      "capricorn"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "♒",
-    "description": "aquarius",
-    "aliases": [
-      "aquarius"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "♓",
-    "description": "pisces",
-    "aliases": [
-      "pisces"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "⛎",
-    "description": "ophiuchus",
-    "aliases": [
-      "ophiuchus"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔯",
-    "description": "six pointed star with middle dot",
-    "aliases": [
-      "six_pointed_star"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🏧",
-    "description": "automated teller machine",
-    "aliases": [
-      "atm"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "💹",
-    "description": "chart with upwards trend and yen sign",
-    "aliases": [
-      "chart"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "💲",
-    "description": "heavy dollar sign",
-    "aliases": [
-      "heavy_dollar_sign"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "💱",
-    "description": "currency exchange",
-    "aliases": [
-      "currency_exchange"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "©",
-    "description": "copyright sign",
-    "aliases": [
-      "copyright"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "®",
-    "description": "registered sign",
-    "aliases": [
-      "registered"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "™",
-    "description": "trade mark sign",
-    "aliases": [
-      "tm"
-    ],
-    "tags": [
-      "trademark"
-    ]
-  },
-  {
-    "emoji": "❌",
-    "description": "cross mark",
-    "aliases": [
-      "x"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "‼",
-    "description": "double exclamation mark",
-    "aliases": [
-      "bangbang"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "⁉",
-    "description": "exclamation question mark",
-    "aliases": [
-      "interrobang"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "❗",
-    "description": "heavy exclamation mark symbol",
-    "aliases": [
-      "exclamation",
-      "heavy_exclamation_mark"
-    ],
-    "tags": [
-      "bang"
-    ]
-  },
-  {
-    "emoji": "❓",
-    "description": "black question mark ornament",
-    "aliases": [
-      "question"
-    ],
-    "tags": [
-      "confused"
-    ]
-  },
-  {
-    "emoji": "❕",
-    "description": "white exclamation mark ornament",
-    "aliases": [
-      "grey_exclamation"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "❔",
-    "description": "white question mark ornament",
-    "aliases": [
-      "grey_question"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "⭕",
-    "description": "heavy large circle",
-    "aliases": [
-      "o"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔝",
-    "description": "top with upwards arrow above",
-    "aliases": [
-      "top"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔚",
-    "description": "end with leftwards arrow above",
-    "aliases": [
-      "end"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔙",
-    "description": "back with leftwards arrow above",
-    "aliases": [
-      "back"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔛",
-    "description": "on with exclamation mark with left right arrow above",
-    "aliases": [
-      "on"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔜",
-    "description": "soon with rightwards arrow above",
-    "aliases": [
-      "soon"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔃",
-    "description": "clockwise downwards and upwards open circle arrows",
-    "aliases": [
-      "arrows_clockwise"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🕛",
-    "description": "clock face twelve oclock",
-    "aliases": [
-      "clock12"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🕧",
-    "description": "clock face twelve-thirty",
-    "aliases": [
-      "clock1230"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🕐",
-    "description": "clock face one oclock",
-    "aliases": [
-      "clock1"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🕜",
-    "description": "clock face one-thirty",
-    "aliases": [
-      "clock130"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🕑",
-    "description": "clock face two oclock",
-    "aliases": [
-      "clock2"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🕝",
-    "description": "clock face two-thirty",
-    "aliases": [
-      "clock230"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🕒",
-    "description": "clock face three oclock",
-    "aliases": [
-      "clock3"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🕞",
-    "description": "clock face three-thirty",
-    "aliases": [
-      "clock330"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🕓",
-    "description": "clock face four oclock",
-    "aliases": [
-      "clock4"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🕟",
-    "description": "clock face four-thirty",
-    "aliases": [
-      "clock430"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🕔",
-    "description": "clock face five oclock",
-    "aliases": [
-      "clock5"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🕠",
-    "description": "clock face five-thirty",
-    "aliases": [
-      "clock530"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🕕",
-    "description": "clock face six oclock",
-    "aliases": [
-      "clock6"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🕖",
-    "description": "clock face seven oclock",
-    "aliases": [
-      "clock7"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🕗",
-    "description": "clock face eight oclock",
-    "aliases": [
-      "clock8"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🕘",
-    "description": "clock face nine oclock",
-    "aliases": [
-      "clock9"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🕙",
-    "description": "clock face ten oclock",
-    "aliases": [
-      "clock10"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🕚",
-    "description": "clock face eleven oclock",
-    "aliases": [
-      "clock11"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🕡",
-    "description": "clock face six-thirty",
-    "aliases": [
-      "clock630"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🕢",
-    "description": "clock face seven-thirty",
-    "aliases": [
-      "clock730"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🕣",
-    "description": "clock face eight-thirty",
-    "aliases": [
-      "clock830"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🕤",
-    "description": "clock face nine-thirty",
-    "aliases": [
-      "clock930"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🕥",
-    "description": "clock face ten-thirty",
-    "aliases": [
-      "clock1030"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🕦",
-    "description": "clock face eleven-thirty",
-    "aliases": [
-      "clock1130"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "✖",
-    "description": "heavy multiplication x",
-    "aliases": [
-      "heavy_multiplication_x"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "➕",
-    "description": "heavy plus sign",
-    "aliases": [
-      "heavy_plus_sign"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "➖",
-    "description": "heavy minus sign",
-    "aliases": [
-      "heavy_minus_sign"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "➗",
-    "description": "heavy division sign",
-    "aliases": [
-      "heavy_division_sign"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "♠",
-    "description": "black spade suit",
-    "aliases": [
-      "spades"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "♥",
-    "description": "black heart suit",
-    "aliases": [
-      "hearts"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "♣",
-    "description": "black club suit",
-    "aliases": [
-      "clubs"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "♦",
-    "description": "black diamond suit",
-    "aliases": [
-      "diamonds"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "💮",
-    "description": "white flower",
-    "aliases": [
-      "white_flower"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "💯",
-    "description": "hundred points symbol",
-    "aliases": [
-      "100"
-    ],
-    "tags": [
-      "score",
-      "perfect"
-    ]
-  },
-  {
-    "emoji": "✔",
-    "description": "heavy check mark",
-    "aliases": [
-      "heavy_check_mark"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "☑",
-    "description": "ballot box with check",
-    "aliases": [
-      "ballot_box_with_check"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔘",
-    "description": "radio button",
-    "aliases": [
-      "radio_button"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔗",
-    "description": "link symbol",
-    "aliases": [
-      "link"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "➰",
-    "description": "curly loop",
-    "aliases": [
-      "curly_loop"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "〰",
-    "description": "wavy dash",
-    "aliases": [
-      "wavy_dash"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "〽",
-    "description": "part alternation mark",
-    "aliases": [
-      "part_alternation_mark"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔱",
-    "description": "trident emblem",
-    "aliases": [
-      "trident"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "◼",
-    "description": "black medium square",
-    "aliases": [
-      "black_medium_square"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "◻",
-    "description": "white medium square",
-    "aliases": [
-      "white_medium_square"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "◾",
-    "description": "black medium small square",
-    "aliases": [
-      "black_medium_small_square"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "◽",
-    "description": "white medium small square",
-    "aliases": [
-      "white_medium_small_square"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "▪",
-    "description": "black small square",
-    "aliases": [
-      "black_small_square"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "▫",
-    "description": "white small square",
-    "aliases": [
-      "white_small_square"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔺",
-    "description": "up-pointing red triangle",
-    "aliases": [
-      "small_red_triangle"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔲",
-    "description": "black square button",
-    "aliases": [
-      "black_square_button"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔳",
-    "description": "white square button",
-    "aliases": [
-      "white_square_button"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "⚫",
-    "description": "medium black circle",
-    "aliases": [
-      "black_circle"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "⚪",
-    "description": "medium white circle",
-    "aliases": [
-      "white_circle"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔴",
-    "description": "large red circle",
-    "aliases": [
-      "red_circle"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔵",
-    "description": "large blue circle",
-    "aliases": [
-      "large_blue_circle"
-    ],
-    "tags": [
-    ]
-  },
-  {
-    "emoji": "🔻",
-    "description": "down-pointing red triangle",
     "aliases": [
       "small_red_triangle_down"
     ],
-    "tags": [
-    ]
+    "description": "down-pointing red triangle",
+    "tags": [],
+    "emoji": "🔻"
   },
   {
-    "emoji": "⬜",
-    "description": "white large square",
     "aliases": [
-      "white_large_square"
+      "small_red_triangle"
     ],
-    "tags": [
-    ]
+    "description": "up-pointing red triangle",
+    "tags": [],
+    "emoji": "🔺"
   },
   {
-    "emoji": "⬛",
-    "description": "black large square",
     "aliases": [
-      "black_large_square"
+      "fire"
     ],
+    "description": "fire",
     "tags": [
-    ]
-  },
-  {
-    "emoji": "🔶",
-    "description": "large orange diamond",
-    "aliases": [
-      "large_orange_diamond"
+      "burn"
     ],
-    "tags": [
-    ]
+    "emoji": "🔥"
   },
   {
-    "emoji": "🔷",
-    "description": "large blue diamond",
     "aliases": [
-      "large_blue_diamond"
+      "three"
     ],
-    "tags": [
-    ]
+    "description": "digit three + combining enclosing keycap",
+    "tags": [],
+    "emoji": "3⃣"
   },
   {
-    "emoji": "🔸",
-    "description": "small orange diamond",
     "aliases": [
-      "small_orange_diamond"
+      "wrench"
     ],
+    "description": "wrench",
     "tags": [
-    ]
-  },
-  {
-    "emoji": "🔹",
-    "description": "small blue diamond",
-    "aliases": [
-      "small_blue_diamond"
+      "tool"
     ],
-    "tags": [
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "afghanistan"
-    ],
-    "description": "regional indicator symbol letter a + regional indicator symbol letter f",
-    "emoji": "🇦🇫",
-    "aliases": [
-      "af"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "albania"
-    ],
-    "description": "regional indicator symbol letter a + regional indicator symbol letter l",
-    "emoji": "🇦🇱",
-    "aliases": [
-      "al"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "algeria"
-    ],
-    "description": "regional indicator symbol letter d + regional indicator symbol letter z",
-    "emoji": "🇩🇿",
-    "aliases": [
-      "dz"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "american samoa"
-    ],
-    "description": "regional indicator symbol letter a + regional indicator symbol letter s",
-    "emoji": "🇦🇸",
-    "aliases": [
-      "as"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "andorra"
-    ],
-    "description": "regional indicator symbol letter a + regional indicator symbol letter d",
-    "emoji": "🇦🇩",
-    "aliases": [
-      "ad"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "angola"
-    ],
-    "description": "regional indicator symbol letter a + regional indicator symbol letter o",
-    "emoji": "🇦🇴",
-    "aliases": [
-      "ao"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "anguilla"
-    ],
-    "description": "regional indicator symbol letter a + regional indicator symbol letter i",
-    "emoji": "🇦🇮",
-    "aliases": [
-      "ai"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "antigua and barbuda"
-    ],
-    "description": "regional indicator symbol letter a + regional indicator symbol letter g",
-    "emoji": "🇦🇬",
-    "aliases": [
-      "ag"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "argentina"
-    ],
-    "description": "regional indicator symbol letter a + regional indicator symbol letter r",
-    "emoji": "🇦🇷",
-    "aliases": [
-      "ar"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "armenia"
-    ],
-    "description": "regional indicator symbol letter a + regional indicator symbol letter m",
-    "emoji": "🇦🇲",
-    "aliases": [
-      "am"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "aruba"
-    ],
-    "description": "regional indicator symbol letter a + regional indicator symbol letter w",
-    "emoji": "🇦🇼",
-    "aliases": [
-      "aw"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "australia"
-    ],
-    "description": "regional indicator symbol letter a + regional indicator symbol letter u",
-    "emoji": "🇦🇺",
-    "aliases": [
-      "au"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "austria"
-    ],
-    "description": "regional indicator symbol letter a + regional indicator symbol letter t",
-    "emoji": "🇦🇹",
-    "aliases": [
-      "at"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "azerbaijan"
-    ],
-    "description": "regional indicator symbol letter a + regional indicator symbol letter z",
-    "emoji": "🇦🇿",
-    "aliases": [
-      "az"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "bahamas"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter s",
-    "emoji": "🇧🇸",
-    "aliases": [
-      "bs"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "bahrain"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter h",
-    "emoji": "🇧🇭",
-    "aliases": [
-      "bh"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "bangladesh"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter d",
-    "emoji": "🇧🇩",
-    "aliases": [
-      "bd"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "barbados"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter b",
-    "emoji": "🇧🇧",
-    "aliases": [
-      "bb"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "belarus"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter y",
-    "emoji": "🇧🇾",
-    "aliases": [
-      "by"
-    ]
+    "emoji": "🔧"
   },
   {
-    "tags": [
-      "flag",
-      "belgium"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter e",
-    "emoji": "🇧🇪",
     "aliases": [
-      "be"
-    ]
+      "flashlight"
+    ],
+    "description": "electric torch",
+    "tags": [],
+    "emoji": "🔦"
   },
   {
-    "tags": [
-      "flag",
-      "belize"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter z",
-    "emoji": "🇧🇿",
     "aliases": [
-      "bz"
-    ]
+      "abcd"
+    ],
+    "description": "input symbol for latin small letters",
+    "tags": [],
+    "emoji": "🔡"
   },
   {
-    "tags": [
-      "flag",
-      "benin"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter j",
-    "emoji": "🇧🇯",
     "aliases": [
-      "bj"
-    ]
+      "mount_fuji"
+    ],
+    "description": "mount fuji",
+    "tags": [],
+    "emoji": "🗻"
   },
   {
-    "tags": [
-      "flag",
-      "bermuda"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter m",
-    "emoji": "🇧🇲",
     "aliases": [
-      "bm"
-    ]
+      "symbols"
+    ],
+    "description": "input symbol for symbols",
+    "tags": [],
+    "emoji": "🔣"
   },
   {
-    "tags": [
-      "flag",
-      "bhutan"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter t",
-    "emoji": "🇧🇹",
     "aliases": [
-      "bt"
-    ]
-  },
-  {
+      "1234"
+    ],
+    "description": "input symbol for numbers",
     "tags": [
-      "flag",
-      "bolivia"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter o",
-    "emoji": "🇧🇴",
-    "aliases": [
-      "bo"
-    ]
+      "numbers"
+    ],
+    "emoji": "🔢"
   },
   {
-    "tags": [
-      "flag",
-      "bosnia and herzegovina"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter a",
-    "emoji": "🇧🇦",
     "aliases": [
-      "ba"
-    ]
+      "telescope"
+    ],
+    "description": "telescope",
+    "tags": [],
+    "emoji": "🔭"
   },
   {
-    "tags": [
-      "flag",
-      "botswana"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter w",
-    "emoji": "🇧🇼",
     "aliases": [
-      "bw"
-    ]
-  },
-  {
+      "microscope"
+    ],
+    "description": "microscope",
     "tags": [
-      "flag",
-      "brazil"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter r",
-    "emoji": "🇧🇷",
-    "aliases": [
-      "br"
-    ]
+      "science",
+      "laboratory",
+      "investigate"
+    ],
+    "emoji": "🔬"
   },
   {
-    "tags": [
-      "flag",
-      "british virgin islands"
-    ],
-    "description": "regional indicator symbol letter v + regional indicator symbol letter g",
-    "emoji": "🇻🇬",
     "aliases": [
-      "vg"
-    ]
+      "six_pointed_star"
+    ],
+    "description": "six pointed star with middle dot",
+    "tags": [],
+    "emoji": "🔯"
   },
   {
-    "tags": [
-      "flag",
-      "brunei darussalam"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter n",
-    "emoji": "🇧🇳",
     "aliases": [
-      "bn"
-    ]
-  },
-  {
+      "crystal_ball"
+    ],
+    "description": "crystal ball",
     "tags": [
-      "flag",
-      "bulgaria"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter g",
-    "emoji": "🇧🇬",
-    "aliases": [
-      "bg"
-    ]
+      "fortune"
+    ],
+    "emoji": "🔮"
   },
   {
-    "tags": [
-      "flag",
-      "burkina faso"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter f",
-    "emoji": "🇧🇫",
     "aliases": [
-      "bf"
-    ]
+      "nut_and_bolt"
+    ],
+    "description": "nut and bolt",
+    "tags": [],
+    "emoji": "🔩"
   },
   {
-    "tags": [
-      "flag",
-      "burundi"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter i",
-    "emoji": "🇧🇮",
     "aliases": [
-      "bi"
-    ]
-  },
-  {
+      "hammer"
+    ],
+    "description": "hammer",
     "tags": [
-      "flag",
-      "cambodia"
-    ],
-    "description": "regional indicator symbol letter k + regional indicator symbol letter h",
-    "emoji": "🇰🇭",
-    "aliases": [
-      "kh"
-    ]
+      "tool"
+    ],
+    "emoji": "🔨"
   },
   {
-    "tags": [
-      "flag",
-      "cameroon"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter m",
-    "emoji": "🇨🇲",
     "aliases": [
-      "cm"
-    ]
-  },
-  {
+      "gun"
+    ],
+    "description": "pistol",
     "tags": [
-      "flag",
-      "canada"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter a",
-    "emoji": "🇨🇦",
-    "aliases": [
-      "ca"
-    ]
+      "shoot",
+      "weapon"
+    ],
+    "emoji": "🔫"
   },
   {
-    "tags": [
-      "flag",
-      "cape verde"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter v",
-    "emoji": "🇨🇻",
     "aliases": [
-      "cv"
-    ]
-  },
-  {
+      "hocho",
+      "knife"
+    ],
+    "description": "hocho",
     "tags": [
-      "flag",
-      "cayman islands"
-    ],
-    "description": "regional indicator symbol letter k + regional indicator symbol letter y",
-    "emoji": "🇰🇾",
-    "aliases": [
-      "ky"
-    ]
+      "cut",
+      "chop"
+    ],
+    "emoji": "🔪"
   },
   {
-    "tags": [
-      "flag",
-      "central african republic"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter f",
-    "emoji": "🇨🇫",
     "aliases": [
-      "cf"
-    ]
-  },
-  {
+      "no_bell"
+    ],
+    "description": "bell with cancellation stroke",
     "tags": [
-      "flag",
-      "chile"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter l",
-    "emoji": "🇨🇱",
-    "aliases": [
-      "cl"
-    ]
+      "volume",
+      "off"
+    ],
+    "emoji": "🔕"
   },
   {
-    "tags": [
-      "flag",
-      "china"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter n",
-    "emoji": "🇨🇳",
     "aliases": [
-      "cn"
-    ]
-  },
-  {
+      "bell"
+    ],
+    "description": "bell",
     "tags": [
-      "flag",
-      "colombia"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter o",
-    "emoji": "🇨🇴",
-    "aliases": [
-      "co"
-    ]
+      "sound",
+      "notification"
+    ],
+    "emoji": "🔔"
   },
   {
-    "tags": [
-      "flag",
-      "comoros"
-    ],
-    "description": "regional indicator symbol letter k + regional indicator symbol letter m",
-    "emoji": "🇰🇲",
     "aliases": [
-      "km"
-    ]
+      "link"
+    ],
+    "description": "link symbol",
+    "tags": [],
+    "emoji": "🔗"
   },
   {
-    "tags": [
-      "flag",
-      "democratic republic of the congo"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter d",
-    "emoji": "🇨🇩",
     "aliases": [
-      "cd"
-    ]
+      "bookmark"
+    ],
+    "description": "bookmark",
+    "tags": [],
+    "emoji": "🔖"
   },
   {
-    "tags": [
-      "flag",
-      "republic of the congo"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter g",
-    "emoji": "🇨🇬",
     "aliases": [
-      "cg"
-    ]
-  },
-  {
+      "key"
+    ],
+    "description": "key",
     "tags": [
-      "flag",
-      "cook islands"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter k",
-    "emoji": "🇨🇰",
-    "aliases": [
-      "ck"
-    ]
+      "lock",
+      "password"
+    ],
+    "emoji": "🔑"
   },
   {
-    "tags": [
-      "flag",
-      "costa rica"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter r",
-    "emoji": "🇨🇷",
     "aliases": [
-      "cr"
-    ]
-  },
-  {
+      "heart"
+    ],
+    "description": "heavy black heart",
     "tags": [
-      "flag",
-      "croatia"
-    ],
-    "description": "regional indicator symbol letter h + regional indicator symbol letter r",
-    "emoji": "🇭🇷",
-    "aliases": [
-      "hr"
-    ]
+      "love"
+    ],
+    "emoji": "❤"
   },
   {
-    "tags": [
-      "flag",
-      "cuba"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter u",
-    "emoji": "🇨🇺",
     "aliases": [
-      "cu"
-    ]
-  },
-  {
+      "unlock"
+    ],
+    "description": "open lock",
     "tags": [
-      "flag",
-      "curacao"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter w",
-    "emoji": "🇨🇼",
-    "aliases": [
-      "cw"
-    ]
+      "security"
+    ],
+    "emoji": "🔓"
   },
   {
-    "tags": [
-      "flag",
-      "cyprus"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter y",
-    "emoji": "🇨🇾",
     "aliases": [
-      "cy"
-    ]
-  },
-  {
+      "lock"
+    ],
+    "description": "lock",
     "tags": [
-      "flag",
-      "czech republic"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter z",
-    "emoji": "🇨🇿",
-    "aliases": [
-      "cz"
-    ]
+      "security",
+      "private"
+    ],
+    "emoji": "🔒"
   },
   {
-    "tags": [
-      "flag",
-      "denmark"
-    ],
-    "description": "regional indicator symbol letter d + regional indicator symbol letter k",
-    "emoji": "🇩🇰",
     "aliases": [
-      "dk"
-    ]
+      "top"
+    ],
+    "description": "top with upwards arrow above",
+    "tags": [],
+    "emoji": "🔝"
   },
   {
-    "tags": [
-      "flag",
-      "djibouti"
-    ],
-    "description": "regional indicator symbol letter d + regional indicator symbol letter j",
-    "emoji": "🇩🇯",
     "aliases": [
-      "dj"
-    ]
+      "soon"
+    ],
+    "description": "soon with rightwards arrow above",
+    "tags": [],
+    "emoji": "🔜"
   },
   {
-    "tags": [
-      "flag",
-      "dominica"
-    ],
-    "description": "regional indicator symbol letter d + regional indicator symbol letter m",
-    "emoji": "🇩🇲",
     "aliases": [
-      "dm"
-    ]
+      "keycap_ten"
+    ],
+    "description": "keycap ten",
+    "tags": [],
+    "emoji": "🔟"
   },
   {
-    "tags": [
-      "flag",
-      "dominican republic"
-    ],
-    "description": "regional indicator symbol letter d + regional indicator symbol letter o",
-    "emoji": "🇩🇴",
     "aliases": [
-      "do"
-    ]
+      "fire_engine"
+    ],
+    "description": "fire engine",
+    "tags": [],
+    "emoji": "🚒"
   },
   {
-    "tags": [
-      "flag",
-      "ecuador"
-    ],
-    "description": "regional indicator symbol letter e + regional indicator symbol letter c",
-    "emoji": "🇪🇨",
     "aliases": [
-      "ec"
-    ]
+      "back"
+    ],
+    "description": "back with leftwards arrow above",
+    "tags": [],
+    "emoji": "🔙"
   },
   {
-    "tags": [
-      "flag",
-      "egypt"
-    ],
-    "description": "regional indicator symbol letter e + regional indicator symbol letter g",
-    "emoji": "🇪🇬",
     "aliases": [
-      "eg"
-    ]
+      "radio_button"
+    ],
+    "description": "radio button",
+    "tags": [],
+    "emoji": "🔘"
   },
   {
-    "tags": [
-      "flag",
-      "el salvador"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter v",
-    "emoji": "🇸🇻",
     "aliases": [
-      "sv"
-    ]
+      "on"
+    ],
+    "description": "on with exclamation mark with left right arrow above",
+    "tags": [],
+    "emoji": "🔛"
   },
   {
-    "tags": [
-      "flag",
-      "equatorial guinea"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter q",
-    "emoji": "🇬🇶",
     "aliases": [
-      "gq"
-    ]
+      "end"
+    ],
+    "description": "end with leftwards arrow above",
+    "tags": [],
+    "emoji": "🔚"
   },
   {
-    "tags": [
-      "flag",
-      "eritrea"
-    ],
-    "description": "regional indicator symbol letter e + regional indicator symbol letter r",
-    "emoji": "🇪🇷",
     "aliases": [
-      "er"
-    ]
+      "low_brightness"
+    ],
+    "description": "low brightness symbol",
+    "tags": [],
+    "emoji": "🔅"
   },
   {
-    "tags": [
-      "flag",
-      "estonia"
-    ],
-    "description": "regional indicator symbol letter e + regional indicator symbol letter e",
-    "emoji": "🇪🇪",
     "aliases": [
-      "ee"
-    ]
+      "monorail"
+    ],
+    "description": "monorail",
+    "tags": [],
+    "emoji": "🚝"
   },
   {
-    "tags": [
-      "flag",
-      "ethiopia"
-    ],
-    "description": "regional indicator symbol letter e + regional indicator symbol letter t",
-    "emoji": "🇪🇹",
     "aliases": [
-      "et"
-    ]
-  },
-  {
+      "mute"
+    ],
+    "description": "speaker with cancellation stroke",
     "tags": [
-      "flag",
-      "faroe islands"
-    ],
-    "description": "regional indicator symbol letter f + regional indicator symbol letter o",
-    "emoji": "🇫🇴",
-    "aliases": [
-      "fo"
-    ]
+      "sound",
+      "volume"
+    ],
+    "emoji": "🔇"
   },
   {
-    "tags": [
-      "flag",
-      "fiji"
-    ],
-    "description": "regional indicator symbol letter f + regional indicator symbol letter j",
-    "emoji": "🇫🇯",
     "aliases": [
-      "fj"
-    ]
+      "high_brightness"
+    ],
+    "description": "high brightness symbol",
+    "tags": [],
+    "emoji": "🔆"
   },
   {
-    "tags": [
-      "flag",
-      "finland"
-    ],
-    "description": "regional indicator symbol letter f + regional indicator symbol letter i",
-    "emoji": "🇫🇮",
     "aliases": [
-      "fi"
-    ]
+      "sailboat",
+      "boat"
+    ],
+    "description": "sailboat",
+    "tags": [],
+    "emoji": "⛵"
   },
   {
-    "tags": [
-      "flag",
-      "france"
-    ],
-    "description": "regional indicator symbol letter f + regional indicator symbol letter r",
-    "emoji": "🇫🇷",
     "aliases": [
-      "fr"
-    ]
-  },
-  {
+      "twisted_rightwards_arrows"
+    ],
+    "description": "twisted rightwards arrows",
     "tags": [
-      "flag",
-      "french guiana"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter f",
-    "emoji": "🇬🇫",
-    "aliases": [
-      "gf"
-    ]
+      "shuffle"
+    ],
+    "emoji": "🔀"
   },
   {
-    "tags": [
-      "flag",
-      "french southern territories"
-    ],
-    "description": "regional indicator symbol letter t + regional indicator symbol letter f",
-    "emoji": "🇹🇫",
     "aliases": [
-      "tf"
-    ]
-  },
-  {
+      "tea"
+    ],
+    "description": "teacup without handle",
     "tags": [
-      "flag",
-      "gabon"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter a",
-    "emoji": "🇬🇦",
-    "aliases": [
-      "ga"
-    ]
+      "green",
+      "breakfast"
+    ],
+    "emoji": "🍵"
   },
   {
-    "tags": [
-      "flag",
-      "gambia"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter m",
-    "emoji": "🇬🇲",
     "aliases": [
-      "gm"
-    ]
+      "tractor"
+    ],
+    "description": "tractor",
+    "tags": [],
+    "emoji": "🚜"
   },
   {
-    "tags": [
-      "flag",
-      "georgia"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter e",
-    "emoji": "🇬🇪",
     "aliases": [
-      "ge"
-    ]
-  },
-  {
+      "mag"
+    ],
+    "description": "left-pointing magnifying glass",
     "tags": [
-      "flag",
-      "germany"
-    ],
-    "description": "regional indicator symbol letter d + regional indicator symbol letter e",
-    "emoji": "🇩🇪",
-    "aliases": [
-      "de"
-    ]
+      "search",
+      "zoom"
+    ],
+    "emoji": "🔍"
   },
   {
-    "tags": [
-      "flag",
-      "ghana"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter h",
-    "emoji": "🇬🇭",
     "aliases": [
-      "gh"
-    ]
+      "electric_plug"
+    ],
+    "description": "electric plug",
+    "tags": [],
+    "emoji": "🔌"
   },
   {
-    "tags": [
-      "flag",
-      "gibraltar"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter i",
-    "emoji": "🇬🇮",
     "aliases": [
-      "gi"
-    ]
+      "lock_with_ink_pen"
+    ],
+    "description": "lock with ink pen",
+    "tags": [],
+    "emoji": "🔏"
   },
   {
-    "tags": [
-      "flag",
-      "greece"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter r",
-    "emoji": "🇬🇷",
     "aliases": [
-      "gr"
-    ]
+      "mag_right"
+    ],
+    "description": "right-pointing magnifying glass",
+    "tags": [],
+    "emoji": "🔎"
   },
   {
-    "tags": [
-      "flag",
-      "grenada"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter d",
-    "emoji": "🇬🇩",
     "aliases": [
-      "gd"
-    ]
-  },
-  {
+      "sound"
+    ],
+    "description": "speaker with one sound wave",
     "tags": [
-      "flag",
-      "guadeloupe"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter p",
-    "emoji": "🇬🇵",
-    "aliases": [
-      "gp"
-    ]
+      "volume"
+    ],
+    "emoji": "🔉"
   },
   {
-    "tags": [
-      "flag",
-      "guam"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter u",
-    "emoji": "🇬🇺",
     "aliases": [
-      "gu"
-    ]
+      "speaker"
+    ],
+    "description": "speaker",
+    "tags": [],
+    "emoji": "🔈"
   },
   {
-    "tags": [
-      "flag",
-      "guatemala"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter t",
-    "emoji": "🇬🇹",
     "aliases": [
-      "gt"
-    ]
-  },
-  {
+      "battery"
+    ],
+    "description": "battery",
     "tags": [
-      "flag",
-      "guinea"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter n",
-    "emoji": "🇬🇳",
-    "aliases": [
-      "gn"
-    ]
+      "power"
+    ],
+    "emoji": "🔋"
   },
   {
-    "tags": [
-      "flag",
-      "guinea-bissau"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter w",
-    "emoji": "🇬🇼",
     "aliases": [
-      "gw"
-    ]
-  },
-  {
+      "loud_sound"
+    ],
+    "description": "speaker with three sound waves",
     "tags": [
-      "flag",
-      "guyana"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter y",
-    "emoji": "🇬🇾",
-    "aliases": [
-      "gy"
-    ]
+      "volume"
+    ],
+    "emoji": "🔊"
   },
   {
-    "tags": [
-      "flag",
-      "haiti"
-    ],
-    "description": "regional indicator symbol letter h + regional indicator symbol letter t",
-    "emoji": "🇭🇹",
     "aliases": [
-      "ht"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "honduras"
-    ],
-    "description": "regional indicator symbol letter h + regional indicator symbol letter n",
-    "emoji": "🇭🇳",
-    "aliases": [
-      "hn"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "hong kong"
-    ],
-    "description": "regional indicator symbol letter h + regional indicator symbol letter k",
-    "emoji": "🇭🇰",
-    "aliases": [
-      "hk"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "hungary"
-    ],
-    "description": "regional indicator symbol letter h + regional indicator symbol letter u",
-    "emoji": "🇭🇺",
-    "aliases": [
-      "hu"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "iceland"
-    ],
-    "description": "regional indicator symbol letter i + regional indicator symbol letter s",
-    "emoji": "🇮🇸",
-    "aliases": [
-      "is"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "india"
-    ],
-    "description": "regional indicator symbol letter i + regional indicator symbol letter n",
-    "emoji": "🇮🇳",
-    "aliases": [
-      "in"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "indonesia"
-    ],
-    "description": "regional indicator symbol letter i + regional indicator symbol letter d",
-    "emoji": "🇮🇩",
-    "aliases": [
-      "id"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "iran"
-    ],
-    "description": "regional indicator symbol letter i + regional indicator symbol letter r",
-    "emoji": "🇮🇷",
-    "aliases": [
-      "ir"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "iraq"
-    ],
-    "description": "regional indicator symbol letter i + regional indicator symbol letter q",
-    "emoji": "🇮🇶",
-    "aliases": [
-      "iq"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "ireland"
-    ],
-    "description": "regional indicator symbol letter i + regional indicator symbol letter e",
-    "emoji": "🇮🇪",
-    "aliases": [
-      "ie"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "israel"
-    ],
-    "description": "regional indicator symbol letter i + regional indicator symbol letter l",
-    "emoji": "🇮🇱",
-    "aliases": [
-      "il"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "italy"
-    ],
-    "description": "regional indicator symbol letter i + regional indicator symbol letter t",
-    "emoji": "🇮🇹",
-    "aliases": [
-      "it"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "ivory coast"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter i",
-    "emoji": "🇨🇮",
-    "aliases": [
-      "ci"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "jamaica"
-    ],
-    "description": "regional indicator symbol letter j + regional indicator symbol letter m",
-    "emoji": "🇯🇲",
-    "aliases": [
-      "jm"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "japan"
-    ],
-    "description": "regional indicator symbol letter j + regional indicator symbol letter p",
-    "emoji": "🇯🇵",
-    "aliases": [
-      "jp"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "jordan"
-    ],
-    "description": "regional indicator symbol letter j + regional indicator symbol letter o",
-    "emoji": "🇯🇴",
-    "aliases": [
-      "jo"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "kazakhstan"
-    ],
-    "description": "regional indicator symbol letter k + regional indicator symbol letter z",
-    "emoji": "🇰🇿",
-    "aliases": [
-      "kz"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "kenya"
-    ],
-    "description": "regional indicator symbol letter k + regional indicator symbol letter e",
-    "emoji": "🇰🇪",
-    "aliases": [
-      "ke"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "kiribati"
-    ],
-    "description": "regional indicator symbol letter k + regional indicator symbol letter i",
-    "emoji": "🇰🇮",
-    "aliases": [
-      "ki"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "kuwait"
-    ],
-    "description": "regional indicator symbol letter k + regional indicator symbol letter w",
-    "emoji": "🇰🇼",
-    "aliases": [
-      "kw"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "kyrgyzstan"
-    ],
-    "description": "regional indicator symbol letter k + regional indicator symbol letter g",
-    "emoji": "🇰🇬",
-    "aliases": [
-      "kg"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "laos"
-    ],
-    "description": "regional indicator symbol letter l + regional indicator symbol letter a",
-    "emoji": "🇱🇦",
-    "aliases": [
-      "la"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "latvia"
-    ],
-    "description": "regional indicator symbol letter l + regional indicator symbol letter v",
-    "emoji": "🇱🇻",
-    "aliases": [
-      "lv"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "lebanon"
-    ],
-    "description": "regional indicator symbol letter l + regional indicator symbol letter b",
-    "emoji": "🇱🇧",
-    "aliases": [
-      "lb"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "lesotho"
-    ],
-    "description": "regional indicator symbol letter l + regional indicator symbol letter s",
-    "emoji": "🇱🇸",
-    "aliases": [
-      "ls"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "liberia"
-    ],
-    "description": "regional indicator symbol letter l + regional indicator symbol letter r",
-    "emoji": "🇱🇷",
-    "aliases": [
-      "lr"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "libya"
-    ],
-    "description": "regional indicator symbol letter l + regional indicator symbol letter y",
-    "emoji": "🇱🇾",
-    "aliases": [
-      "ly"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "liechtenstein"
-    ],
-    "description": "regional indicator symbol letter l + regional indicator symbol letter i",
-    "emoji": "🇱🇮",
-    "aliases": [
-      "li"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "lithuania"
-    ],
-    "description": "regional indicator symbol letter l + regional indicator symbol letter t",
-    "emoji": "🇱🇹",
-    "aliases": [
-      "lt"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "luxembourg"
-    ],
-    "description": "regional indicator symbol letter l + regional indicator symbol letter u",
-    "emoji": "🇱🇺",
-    "aliases": [
-      "lu"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "macau"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter o",
-    "emoji": "🇲🇴",
-    "aliases": [
-      "mo"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "macedonia"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter k",
-    "emoji": "🇲🇰",
-    "aliases": [
-      "mk"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "madagascar"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter g",
-    "emoji": "🇲🇬",
-    "aliases": [
-      "mg"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "malawi"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter w",
-    "emoji": "🇲🇼",
-    "aliases": [
-      "mw"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "malaysia"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter y",
-    "emoji": "🇲🇾",
-    "aliases": [
-      "my"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "maldives"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter v",
-    "emoji": "🇲🇻",
-    "aliases": [
-      "mv"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "mali"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter l",
-    "emoji": "🇲🇱",
-    "aliases": [
-      "ml"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "malta"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter t",
-    "emoji": "🇲🇹",
-    "aliases": [
-      "mt"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "martinique"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter q",
-    "emoji": "🇲🇶",
-    "aliases": [
-      "mq"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "mauritania"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter r",
-    "emoji": "🇲🇷",
-    "aliases": [
-      "mr"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "mexico"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter x",
-    "emoji": "🇲🇽",
-    "aliases": [
-      "mx"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "moldova"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter d",
-    "emoji": "🇲🇩",
-    "aliases": [
-      "md"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "mongolia"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter n",
-    "emoji": "🇲🇳",
-    "aliases": [
-      "mn"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "montenegro"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter e",
-    "emoji": "🇲🇪",
-    "aliases": [
-      "me"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "montserrat"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter s",
-    "emoji": "🇲🇸",
-    "aliases": [
-      "ms"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "morocco"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter a",
-    "emoji": "🇲🇦",
-    "aliases": [
-      "ma"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "mozambique"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter z",
-    "emoji": "🇲🇿",
-    "aliases": [
-      "mz"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "myanmar"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter m",
-    "emoji": "🇲🇲",
-    "aliases": [
-      "mm"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "namibia"
-    ],
-    "description": "regional indicator symbol letter n + regional indicator symbol letter a",
-    "emoji": "🇳🇦",
-    "aliases": [
-      "na"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "nepal"
-    ],
-    "description": "regional indicator symbol letter n + regional indicator symbol letter p",
-    "emoji": "🇳🇵",
-    "aliases": [
-      "np"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "netherlands"
-    ],
-    "description": "regional indicator symbol letter n + regional indicator symbol letter l",
-    "emoji": "🇳🇱",
-    "aliases": [
-      "nl"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "new caledonia"
-    ],
-    "description": "regional indicator symbol letter n + regional indicator symbol letter c",
-    "emoji": "🇳🇨",
-    "aliases": [
-      "nc"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "new zealand"
-    ],
-    "description": "regional indicator symbol letter n + regional indicator symbol letter z",
-    "emoji": "🇳🇿",
-    "aliases": [
-      "nz"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "nicaragua"
-    ],
-    "description": "regional indicator symbol letter n + regional indicator symbol letter i",
-    "emoji": "🇳🇮",
-    "aliases": [
-      "ni"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "niger"
-    ],
-    "description": "regional indicator symbol letter n + regional indicator symbol letter e",
-    "emoji": "🇳🇪",
-    "aliases": [
-      "ne"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "nigeria"
-    ],
-    "description": "regional indicator symbol letter n + regional indicator symbol letter g",
-    "emoji": "🇳🇬",
-    "aliases": [
-      "ng"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "niue"
-    ],
-    "description": "regional indicator symbol letter n + regional indicator symbol letter u",
-    "emoji": "🇳🇺",
-    "aliases": [
-      "nu"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "north korea"
-    ],
-    "description": "regional indicator symbol letter k + regional indicator symbol letter p",
-    "emoji": "🇰🇵",
-    "aliases": [
-      "kp"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "northern mariana islands"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter p",
-    "emoji": "🇲🇵",
-    "aliases": [
-      "mp"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "norway"
-    ],
-    "description": "regional indicator symbol letter n + regional indicator symbol letter o",
-    "emoji": "🇳🇴",
-    "aliases": [
-      "no"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "oman"
-    ],
-    "description": "regional indicator symbol letter o + regional indicator symbol letter m",
-    "emoji": "🇴🇲",
-    "aliases": [
-      "om"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "pakistan"
-    ],
-    "description": "regional indicator symbol letter p + regional indicator symbol letter k",
-    "emoji": "🇵🇰",
-    "aliases": [
-      "pk"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "palau"
-    ],
-    "description": "regional indicator symbol letter p + regional indicator symbol letter w",
-    "emoji": "🇵🇼",
-    "aliases": [
-      "pw"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "palestine"
-    ],
-    "description": "regional indicator symbol letter p + regional indicator symbol letter s",
-    "emoji": "🇵🇸",
-    "aliases": [
-      "ps"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "panama"
-    ],
-    "description": "regional indicator symbol letter p + regional indicator symbol letter a",
-    "emoji": "🇵🇦",
-    "aliases": [
-      "pa"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "papua new guinea"
-    ],
-    "description": "regional indicator symbol letter p + regional indicator symbol letter g",
-    "emoji": "🇵🇬",
-    "aliases": [
-      "pg"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "paraguay"
-    ],
-    "description": "regional indicator symbol letter p + regional indicator symbol letter y",
-    "emoji": "🇵🇾",
-    "aliases": [
-      "py"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "peru"
-    ],
-    "description": "regional indicator symbol letter p + regional indicator symbol letter e",
-    "emoji": "🇵🇪",
-    "aliases": [
-      "pe"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "philippines"
-    ],
-    "description": "regional indicator symbol letter p + regional indicator symbol letter h",
-    "emoji": "🇵🇭",
-    "aliases": [
-      "ph"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "polnad"
-    ],
-    "description": "regional indicator symbol letter p + regional indicator symbol letter l",
-    "emoji": "🇵🇱",
-    "aliases": [
-      "pl"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "portugal"
-    ],
-    "description": "regional indicator symbol letter p + regional indicator symbol letter t",
-    "emoji": "🇵🇹",
-    "aliases": [
-      "pt"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "puerto rico"
-    ],
-    "description": "regional indicator symbol letter p + regional indicator symbol letter r",
-    "emoji": "🇵🇷",
-    "aliases": [
-      "pr"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "qatar"
-    ],
-    "description": "regional indicator symbol letter q + regional indicator symbol letter a",
-    "emoji": "🇶🇦",
-    "aliases": [
-      "qa"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "reunion"
-    ],
-    "description": "regional indicator symbol letter r + regional indicator symbol letter e",
-    "emoji": "🇷🇪",
-    "aliases": [
-      "re"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "romania"
-    ],
-    "description": "regional indicator symbol letter r + regional indicator symbol letter o",
-    "emoji": "🇷🇴",
-    "aliases": [
-      "ro"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "russia"
-    ],
-    "description": "regional indicator symbol letter r + regional indicator symbol letter u",
-    "emoji": "🇷🇺",
-    "aliases": [
-      "ru"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "rwanda"
-    ],
-    "description": "regional indicator symbol letter r + regional indicator symbol letter w",
-    "emoji": "🇷🇼",
-    "aliases": [
-      "rw"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "samoa"
-    ],
-    "description": "regional indicator symbol letter w + regional indicator symbol letter s",
-    "emoji": "🇼🇸",
-    "aliases": [
-      "ws"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "san marino"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter m",
-    "emoji": "🇸🇲",
-    "aliases": [
-      "sm"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "sao tome and principe"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter t",
-    "emoji": "🇸🇹",
-    "aliases": [
-      "st"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "saudi arabia"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter a",
-    "emoji": "🇸🇦",
-    "aliases": [
-      "sa"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "senegal"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter n",
-    "emoji": "🇸🇳",
-    "aliases": [
-      "sn"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "serbia"
-    ],
-    "description": "regional indicator symbol letter r + regional indicator symbol letter s",
-    "emoji": "🇷🇸",
-    "aliases": [
-      "rs"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "seychelles"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter c",
-    "emoji": "🇸🇨",
-    "aliases": [
-      "sc"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "sierra leone"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter l",
-    "emoji": "🇸🇱",
-    "aliases": [
-      "sl"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "singapore"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter g",
-    "emoji": "🇸🇬",
-    "aliases": [
-      "sg"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "slovakia"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter k",
-    "emoji": "🇸🇰",
-    "aliases": [
-      "sk"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "slovenia"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter i",
-    "emoji": "🇸🇮",
-    "aliases": [
-      "si"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "solomon islands"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter b",
-    "emoji": "🇸🇧",
-    "aliases": [
-      "sb"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "somalia"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter o",
-    "emoji": "🇸🇴",
-    "aliases": [
-      "so"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "south africa"
-    ],
-    "description": "regional indicator symbol letter z + regional indicator symbol letter a",
-    "emoji": "🇿🇦",
-    "aliases": [
-      "za"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "south korea"
-    ],
-    "description": "regional indicator symbol letter k + regional indicator symbol letter r",
-    "emoji": "🇰🇷",
-    "aliases": [
-      "kr"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "south sudan"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter s",
-    "emoji": "🇸🇸",
-    "aliases": [
-      "ss"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "spain"
-    ],
-    "description": "regional indicator symbol letter e + regional indicator symbol letter s",
-    "emoji": "🇪🇸",
-    "aliases": [
-      "es"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "sri lanka"
-    ],
-    "description": "regional indicator symbol letter l + regional indicator symbol letter k",
-    "emoji": "🇱🇰",
-    "aliases": [
-      "lk"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "sudan"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter d",
-    "emoji": "🇸🇩",
-    "aliases": [
-      "sd"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "suriname"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter r",
-    "emoji": "🇸🇷",
-    "aliases": [
-      "sr"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "swaziland"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter z",
-    "emoji": "🇸🇿",
-    "aliases": [
-      "sz"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "sweden"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter e",
-    "emoji": "🇸🇪",
-    "aliases": [
-      "se"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "switzerland"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter h",
-    "emoji": "🇨🇭",
-    "aliases": [
-      "ch"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "syria"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter y",
-    "emoji": "🇸🇾",
-    "aliases": [
-      "sy"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "tajikistan"
-    ],
-    "description": "regional indicator symbol letter t + regional indicator symbol letter j",
-    "emoji": "🇹🇯",
-    "aliases": [
-      "tj"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "tanzania"
-    ],
-    "description": "regional indicator symbol letter t + regional indicator symbol letter z",
-    "emoji": "🇹🇿",
-    "aliases": [
-      "tz"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "thailand"
-    ],
-    "description": "regional indicator symbol letter t + regional indicator symbol letter h",
-    "emoji": "🇹🇭",
-    "aliases": [
-      "th"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "east timor"
-    ],
-    "description": "regional indicator symbol letter t + regional indicator symbol letter l",
-    "emoji": "🇹🇱",
-    "aliases": [
-      "tl"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "togo"
-    ],
-    "description": "regional indicator symbol letter t + regional indicator symbol letter g",
-    "emoji": "🇹🇬",
-    "aliases": [
-      "tg"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "tonga"
-    ],
-    "description": "regional indicator symbol letter t + regional indicator symbol letter o",
-    "emoji": "🇹🇴",
-    "aliases": [
-      "to"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "trinidad and tobago"
-    ],
-    "description": "regional indicator symbol letter t + regional indicator symbol letter t",
-    "emoji": "🇹🇹",
-    "aliases": [
-      "tt"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "tunisia"
-    ],
-    "description": "regional indicator symbol letter t + regional indicator symbol letter n",
-    "emoji": "🇹🇳",
-    "aliases": [
-      "tn"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "turkey"
-    ],
-    "description": "regional indicator symbol letter t + regional indicator symbol letter r",
-    "emoji": "🇹🇷",
-    "aliases": [
-      "tr"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "turkmenistan"
-    ],
-    "description": "regional indicator symbol letter t + regional indicator symbol letter m",
-    "emoji": "🇹🇲",
-    "aliases": [
-      "tm"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "turks and caicos islands"
-    ],
-    "description": "regional indicator symbol letter t + regional indicator symbol letter c",
-    "emoji": "🇹🇨",
-    "aliases": [
-      "tc"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "tuvalu"
-    ],
-    "description": "regional indicator symbol letter t + regional indicator symbol letter v",
-    "emoji": "🇹🇻",
-    "aliases": [
-      "tv"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "uganda"
-    ],
-    "description": "regional indicator symbol letter u + regional indicator symbol letter g",
-    "emoji": "🇺🇬",
-    "aliases": [
-      "ug"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "ukraine"
-    ],
-    "description": "regional indicator symbol letter u + regional indicator symbol letter a",
-    "emoji": "🇺🇦",
-    "aliases": [
-      "ua"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "united arab emirates"
-    ],
-    "description": "regional indicator symbol letter a + regional indicator symbol letter e",
-    "emoji": "🇦🇪",
-    "aliases": [
-      "ae"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "united kingdom"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter b",
-    "emoji": "🇬🇧",
-    "aliases": [
-      "gb"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "uruguay"
-    ],
-    "description": "regional indicator symbol letter u + regional indicator symbol letter y",
-    "emoji": "🇺🇾",
-    "aliases": [
-      "uy"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "united states of america"
-    ],
-    "description": "regional indicator symbol letter u + regional indicator symbol letter s",
-    "emoji": "🇺🇸",
-    "aliases": [
-      "us"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "us virgin islands"
-    ],
-    "description": "regional indicator symbol letter v + regional indicator symbol letter i",
-    "emoji": "🇻🇮",
-    "aliases": [
-      "vi"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "uzbekistan"
-    ],
-    "description": "regional indicator symbol letter u + regional indicator symbol letter z",
-    "emoji": "🇺🇿",
-    "aliases": [
-      "uz"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "st vincent grenadines"
-    ],
-    "description": "regional indicator symbol letter v + regional indicator symbol letter c",
-    "emoji": "🇻🇨",
-    "aliases": [
-      "vc"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "vanuatu"
-    ],
-    "description": "regional indicator symbol letter v + regional indicator symbol letter u",
-    "emoji": "🇻🇺",
-    "aliases": [
-      "vu"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "venezuela"
-    ],
-    "description": "regional indicator symbol letter v + regional indicator symbol letter e",
-    "emoji": "🇻🇪",
-    "aliases": [
-      "ve"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "vietnam"
-    ],
-    "description": "regional indicator symbol letter v + regional indicator symbol letter n",
-    "emoji": "🇻🇳",
-    "aliases": [
-      "vn"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "yemen"
-    ],
-    "description": "regional indicator symbol letter y + regional indicator symbol letter e",
-    "emoji": "🇾🇪",
-    "aliases": [
-      "ye"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "zambia"
-    ],
-    "description": "regional indicator symbol letter z + regional indicator symbol letter m",
-    "emoji": "🇿🇲",
-    "aliases": [
-      "zm"
-    ]
-  },
-  {
-    "tags": [
-      "flag",
-      "zimbabwe"
-    ],
-    "description": "regional indicator symbol letter z + regional indicator symbol letter w",
-    "emoji": "🇿🇼",
-    "aliases": [
-      "zw"
-    ]
-  },
-  {
-    "tags": [
-      "letter",
-      "a"
-    ],
-    "description": "regional indicator symbol letter a",
-    "emoji": "🇦",
-    "aliases": [
-      "regional_indicator_symbol_a"
-    ]
-  },
-  {
-    "tags": [
-      "letter",
-      "b"
-    ],
-    "description": "regional indicator symbol letter b",
-    "emoji": "🇧",
-    "aliases": [
-      "regional_indicator_symbol_b"
-    ]
-  },
-  {
-    "tags": [
-      "letter",
-      "c"
-    ],
-    "description": "regional indicator symbol letter c",
-    "emoji": "🇨",
-    "aliases": [
-      "regional_indicator_symbol_c"
-    ]
-  },
-  {
-    "tags": [
-      "letter",
-      "d"
-    ],
-    "description": "regional indicator symbol letter d",
-    "emoji": "🇩",
-    "aliases": [
-      "regional_indicator_symbol_d"
-    ]
-  },
-  {
-    "tags": [
-      "letter",
-      "e"
-    ],
-    "description": "regional indicator symbol letter e",
-    "emoji": "🇪",
-    "aliases": [
-      "regional_indicator_symbol_e"
-    ]
-  },
-  {
-    "tags": [
-      "letter",
-      "f"
-    ],
-    "description": "regional indicator symbol letter f",
-    "emoji": "🇫",
-    "aliases": [
-      "regional_indicator_symbol_f"
-    ]
-  },
-  {
-    "tags": [
-      "letter",
-      "g"
-    ],
-    "description": "regional indicator symbol letter g",
-    "emoji": "🇬",
-    "aliases": [
-      "regional_indicator_symbol_g"
-    ]
-  },
-  {
-    "tags": [
-      "letter",
-      "h"
-    ],
-    "description": "regional indicator symbol letter h",
-    "emoji": "🇭",
-    "aliases": [
-      "regional_indicator_symbol_h"
-    ]
-  },
-  {
-    "tags": [
-      "letter",
-      "i"
-    ],
-    "description": "regional indicator symbol letter i",
-    "emoji": "🇮",
-    "aliases": [
-      "regional_indicator_symbol_i"
-    ]
-  },
-  {
-    "tags": [
-      "letter",
-      "j"
-    ],
-    "description": "regional indicator symbol letter j",
-    "emoji": "🇯",
-    "aliases": [
-      "regional_indicator_symbol_j"
-    ]
-  },
-  {
-    "tags": [
-      "letter",
-      "k"
-    ],
-    "description": "regional indicator symbol letter k",
-    "emoji": "🇰",
-    "aliases": [
-      "regional_indicator_symbol_k"
-    ]
-  },
-  {
-    "tags": [
-      "letter",
-      "l"
-    ],
-    "description": "regional indicator symbol letter l",
-    "emoji": "🇱",
-    "aliases": [
-      "regional_indicator_symbol_l"
-    ]
-  },
-  {
-    "tags": [
-      "letter",
-      "m"
-    ],
-    "description": "regional indicator symbol letter m",
-    "emoji": "🇲",
-    "aliases": [
-      "regional_indicator_symbol_m"
-    ]
-  },
-  {
-    "tags": [
-      "letter",
-      "n"
-    ],
-    "description": "regional indicator symbol letter n",
-    "emoji": "🇳",
-    "aliases": [
-      "regional_indicator_symbol_n"
-    ]
-  },
-  {
-    "tags": [
-      "letter",
-      "o"
-    ],
-    "description": "regional indicator symbol letter o",
-    "emoji": "🇴",
-    "aliases": [
-      "regional_indicator_symbol_o"
-    ]
-  },
-  {
-    "tags": [
-      "letter",
-      "p"
-    ],
-    "description": "regional indicator symbol letter p",
-    "emoji": "🇵",
-    "aliases": [
-      "regional_indicator_symbol_p"
-    ]
-  },
-  {
+      "regional_indicator_symbol_q"
+    ],
+    "emoji": "🇶",
+    "description": "regional indicator symbol letter q",
     "tags": [
       "letter",
       "q"
-    ],
-    "description": "regional indicator symbol letter q",
-    "emoji": "🇶",
-    "aliases": [
-      "regional_indicator_symbol_q"
     ]
   },
   {
+    "aliases": [
+      "mountain_railway"
+    ],
+    "description": "mountain railway",
+    "tags": [],
+    "emoji": "🚞"
+  },
+  {
+    "aliases": [
+      "wavy_dash"
+    ],
+    "description": "wavy dash",
+    "tags": [],
+    "emoji": "〰"
+  },
+  {
+    "aliases": [
+      "arrow_down"
+    ],
+    "description": "downwards black arrow",
+    "tags": [],
+    "emoji": "⬇"
+  },
+  {
+    "aliases": [
+      "lr",
+      "flag-lr"
+    ],
+    "emoji": "🇱🇷",
+    "description": "regional indicator symbol letter l + regional indicator symbol letter r",
+    "tags": [
+      "flag",
+      "liberia"
+    ]
+  },
+  {
+    "aliases": [
+      "statue_of_liberty"
+    ],
+    "description": "statue of liberty",
+    "tags": [],
+    "emoji": "🗽"
+  },
+  {
+    "aliases": [
+      "tokyo_tower"
+    ],
+    "description": "tokyo tower",
+    "tags": [],
+    "emoji": "🗼"
+  },
+  {
+    "aliases": [
+      "moyai"
+    ],
+    "description": "moyai",
+    "tags": [
+      "stone"
+    ],
+    "emoji": "🗿"
+  },
+  {
+    "aliases": [
+      "japan"
+    ],
+    "description": "silhouette of japan",
+    "tags": [],
+    "emoji": "🗾"
+  },
+  {
+    "aliases": [
+      "regional_indicator_symbol_c"
+    ],
+    "emoji": "🇨",
+    "description": "regional indicator symbol letter c",
     "tags": [
       "letter",
-      "r"
-    ],
-    "description": "regional indicator symbol letter r",
-    "emoji": "🇷",
-    "aliases": [
-      "regional_indicator_symbol_r"
+      "c"
     ]
   },
   {
+    "aliases": [
+      "regional_indicator_symbol_o"
+    ],
+    "emoji": "🇴",
+    "description": "regional indicator symbol letter o",
     "tags": [
       "letter",
-      "s"
-    ],
-    "description": "regional indicator symbol letter s",
-    "emoji": "🇸",
-    "aliases": [
-      "regional_indicator_symbol_s"
+      "o"
     ]
   },
   {
+    "aliases": [
+      "pencil2"
+    ],
+    "description": "pencil",
+    "tags": [],
+    "emoji": "✏"
+  },
+  {
+    "aliases": [
+      "oncoming_automobile"
+    ],
+    "description": "oncoming automobile",
+    "tags": [],
+    "emoji": "🚘"
+  },
+  {
+    "aliases": [
+      "no_bicycles"
+    ],
+    "description": "no bicycles",
+    "tags": [],
+    "emoji": "🚳"
+  },
+  {
+    "aliases": [
+      "regional_indicator_symbol_p"
+    ],
+    "emoji": "🇵",
+    "description": "regional indicator symbol letter p",
     "tags": [
       "letter",
-      "t"
-    ],
-    "description": "regional indicator symbol letter t",
-    "emoji": "🇹",
-    "aliases": [
-      "regional_indicator_symbol_t"
+      "p"
     ]
   },
   {
+    "aliases": [
+      "coffee"
+    ],
+    "description": "hot beverage",
     "tags": [
-      "letter",
-      "u"
+      "cafe",
+      "espresso"
     ],
-    "description": "regional indicator symbol letter u",
-    "emoji": "🇺",
-    "aliases": [
-      "regional_indicator_symbol_u"
-    ]
+    "emoji": "☕"
   },
   {
-    "tags": [
-      "letter",
-      "v"
-    ],
-    "description": "regional indicator symbol letter v",
-    "emoji": "🇻",
     "aliases": [
-      "regional_indicator_symbol_v"
-    ]
+      "articulated_lorry"
+    ],
+    "description": "articulated lorry",
+    "tags": [],
+    "emoji": "🚛"
   },
   {
-    "tags": [
-      "letter",
-      "w"
-    ],
-    "description": "regional indicator symbol letter w",
-    "emoji": "🇼",
-    "aliases": [
-      "regional_indicator_symbol_w"
-    ]
-  },
-  {
-    "tags": [
-      "letter",
-      "x"
-    ],
-    "description": "regional indicator symbol letter x",
-    "emoji": "🇽",
-    "aliases": [
-      "regional_indicator_symbol_x"
-    ]
-  },
-  {
-    "tags": [
-      "letter",
-      "y"
-    ],
-    "description": "regional indicator symbol letter y",
-    "emoji": "🇾",
-    "aliases": [
-      "regional_indicator_symbol_y"
-    ]
-  },
-  {
-    "tags": [
-      "letter",
-      "z"
-    ],
-    "description": "regional indicator symbol letter z",
-    "emoji": "🇿",
-    "aliases": [
-      "regional_indicator_symbol_z"
-    ]
-  },
-
-  {
-    "emoji": "👨‍👩‍👦",
-    "description": "family (man, woman, boy)",
-    "aliases": [
-      "family_man_woman_boy"
-    ],
-    "tags": [
-      "family",
-      "man",
-      "woman",
-      "boy"
-    ]
-  },
-  {
-    "emoji": "👨‍👩‍👧",
-    "description": "family (man, woman, girl)",
-    "aliases": [
-      "family_man_woman_girl"
-    ],
-    "tags": [
-      "family",
-      "man",
-      "woman",
-      "girl"
-    ]
-  },
-  {
-    "emoji": "👨‍👩‍👦‍👦",
-    "description": "family (man, woman, boy, boy)",
-    "aliases": [
-      "family_man_woman_boy_boy"
-    ],
-    "tags": [
-      "family",
-      "man",
-      "woman",
-      "boy"
-    ]
-  },
-  {
-    "emoji": "👨‍👩‍👧‍👧",
-    "description": "family (man, woman, girl, girl)",
-    "aliases": [
-      "family_man_woman_girl_girl"
-    ],
-    "tags": [
-      "family",
-      "man",
-      "woman",
-      "girl"
-    ]
-  },
-  {
-    "emoji": "👩‍👩‍👦",
-    "description": "family (woman, woman, boy)",
-    "aliases": [
-      "family_woman_woman_boy"
-    ],
-    "tags": [
-      "family",
-      "woman",
-      "boy"
-    ]
-  },
-  {
-    "emoji": "👩‍👩‍👧",
-    "description": "family (woman, woman, girl)",
-    "aliases": [
-      "family_woman_woman_girl"
-    ],
-    "tags": [
-      "family",
-      "woman",
-      "girl"
-    ]
-  },
-  {
-    "emoji": "👩‍👩‍👧‍👦",
-    "description": "family (woman, woman, girl, boy)",
-    "aliases": [
-      "family_woman_woman_girl_boy"
-    ],
-    "tags": [
-      "family",
-      "woman",
-      "girl",
-      "boy"
-    ]
-  },
-  {
-    "emoji": "👩‍👩‍👦‍👦",
-    "description": "family (woman, woman, boy, boy)",
-    "aliases": [
-      "family_woman_woman_boy_boy"
-    ],
-    "tags": [
-      "family",
-      "woman",
-      "boy"
-    ]
-  },
-  {
-    "emoji": "👩‍👩‍👧‍👧",
-    "description": "family (woman, woman, girl, girl)",
-    "aliases": [
-      "family_woman_woman_girl_girl"
-    ],
-    "tags": [
-      "family",
-      "woman",
-      "girl"
-    ]
-  },
-  {
-    "emoji": "👨‍👨‍👦",
-    "description": "family (man, man, boy)",
-    "aliases": [
-      "family_man_man_boy"
-    ],
-    "tags": [
-      "family",
-      "man",
-      "boy"
-    ]
-  },
-  {
-    "emoji": "👨‍👨‍👧",
-    "description": "family (man, man, girl)",
-    "aliases": [
-      "family_man_man_girl"
-    ],
-    "tags": [
-      "family",
-      "man",
-      "girl"
-    ]
-  },
-  {
-    "emoji": "👨‍👨‍👧‍👦",
-    "description": "family (man, man, girl, boy)",
-    "aliases": [
-      "family_man_man_girl_boy"
-    ],
-    "tags": [
-      "family",
-      "man",
-      "girl",
-      "boy"
-    ]
-  },
-  {
-    "emoji": "👨‍👨‍👦‍👦",
-    "description": "family (man, man, boy, boy)",
-    "aliases": [
-      "family_man_man_boy_boy"
-    ],
-    "tags": [
-      "family",
-      "man",
-      "boy"
-    ]
-  },
-  {
-    "emoji": "👨‍👨‍👧‍👧",
-    "description": "family (man, man, girl, girl)",
-    "aliases": [
-      "family_man_man_girl_girl"
-    ],
-    "tags": [
-      "family",
-      "man",
-      "girl"
-    ]
-  },
-  {
-    "emoji": "👩‍❤‍👩",
-    "description": "couple with heart (woman, woman)",
-    "aliases": [
-      "couple_with_heart_woman_woman"
-    ],
-    "tags": [
-      "couple",
-      "heart",
-      "woman"
-    ]
-  },
-  {
-    "emoji": "👨‍❤‍👨",
-    "description": "couple with heart (man, man)",
-    "aliases": [
-      "couple_with_heart_man_man"
-    ],
-    "tags": [
-      "couple",
-      "heart",
-      "man"
-    ]
-  },
-  {
-    "emoji": "👩‍❤‍💋‍👩",
-    "description": "kiss (woman, woman)",
-    "aliases": [
-      "couplekiss_woman_woman"
-    ],
-    "tags": [
-      "couple",
-      "kiss",
-      "woman"
-    ]
-  },
-  {
-    "emoji": "👨‍❤‍💋‍👨",
-    "description": "kiss (man, man)",
-    "aliases": [
-      "couplekiss_man_man"
-    ],
-    "tags": [
-      "couple",
-      "kiss",
-      "man"
-    ]
-  },
-  {
-    "emoji": "🖖",
-    "description": "raised hand with part between middle and ring fingers",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "vulcan_salute"
-    ],
-    "tags": [
-      "vulcan",
-      "salute"
-    ]
-  },
-  {
-    "emoji": "🖕",
-    "description": "reversed hand with middle finger extended",
-    "supports_fitzpatrick": true,
-    "aliases": [
-      "middle_finger"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🙂",
-    "description": "slightly smiling face",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "slightly_smiling"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🤗",
-    "description": "hugging face",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "hugging",
-      "hug",
-      "hugs"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🤔",
-    "description": "thinking face",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "thinking",
-      "think",
-      "thinker"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🙄",
-    "description": "face with rolling eyes",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "eye_roll",
-      "rolling_eyes"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🤐",
-    "description": "zipper-mouth face",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "zipper_mouth",
-      "zip_it",
-      "sealed_lips",
-      "lips_sealed"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🤓",
-    "description": "nerd face",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "nerd",
-      "nerdy"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "☹",
-    "description": "white frowning face",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "frowning_face"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🙁",
-    "description": "slightly frowning face",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "slightly_frowning"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🙃",
-    "description": "upside-down face",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "upside_down",
-      "flipped_face"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🤒",
-    "description": "face with thermometer",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "sick",
-      "ill",
-      "thermometer_face"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🤕",
-    "description": "face with head bandage",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "injured",
-      "head_bandage",
-      "head_bandaged",
-      "bandaged"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🤑",
-    "description": "money-mouth face",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "money_mouth",
-      "money_face"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "⛑",
-    "description": "helmet with white crosse",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "helmet_white_cross"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🕵",
-    "description": "sleuth or spy",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "detective",
-      "sleuth",
-      "private_eye",
-      "spy"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🗣",
-    "description": "speaking head in silhouette",
-    "supports_fitzpatrick": false,
     "aliases": [
       "speaking_head_in_silhouette"
     ],
-    "tags": []
-  },
-  {
-    "emoji": "🕴",
-    "description": "man in business suit levitating",
     "supports_fitzpatrick": false,
-    "aliases": [
-      "hovering_man",
-      "levitating_man"
-    ],
-    "tags": []
+    "description": "speaking head in silhouette",
+    "tags": [],
+    "emoji": "🗣"
   },
   {
-    "emoji": "🤘",
-    "description": "sign of the horns",
-    "supports_fitzpatrick": true,
     "aliases": [
-      "horns_sign",
-      "rock_on",
-      "heavy_metal",
-      "devil_fingers"
+      "arrow_lower_right"
     ],
-    "tags": []
+    "description": "south east arrow",
+    "tags": [],
+    "emoji": "↘"
   },
   {
-    "emoji": "🖐",
-    "description": "raised hand with five fingers splayed",
-    "supports_fitzpatrick": true,
     "aliases": [
-      "raised_hand_with_fingers_splayed",
-      "splayed_hand"
+      "regional_indicator_symbol_m"
     ],
-    "tags": []
+    "emoji": "🇲",
+    "description": "regional indicator symbol letter m",
+    "tags": [
+      "letter",
+      "m"
+    ]
   },
   {
-    "emoji": "✍",
-    "description": "writing hand",
-    "supports_fitzpatrick": true,
     "aliases": [
-      "writing",
-      "writing_hand"
+      "zig_zag_bubble",
+      "right_anger_bubble"
     ],
-    "tags": []
-  },
-  {
-    "emoji": "👁",
-    "description": "eye",
     "supports_fitzpatrick": false,
-    "aliases": [
-      "eye"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "❣",
-    "description": "heavy heart exclamation mark ornament",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "exclamation_heart"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🕳",
-    "description": "hole",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "hole"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🗯",
     "description": "right anger bubble",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "right_anger_bubble",
-      "zig_zag_bubble"
-    ],
-    "tags": []
+    "tags": [],
+    "emoji": "🗯"
   },
   {
-    "emoji": "🕶",
-    "description": "dark sunglasses",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "dark_sunglasses"
+      "truck"
     ],
-    "tags": []
+    "description": "delivery truck",
+    "tags": [],
+    "emoji": "🚚"
   },
   {
-    "emoji": "🛍",
-    "description": "shopping bags",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "shopping_bags"
+      "left_speech_bubble"
     ],
-    "tags": []
+    "supports_fitzpatrick": false,
+    "description": "left speech bubble",
+    "tags": [],
+    "emoji": "🗨"
   },
   {
-    "emoji": "📿",
-    "description": "prayer beads",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "prayer_beads",
-      "dhikr_beads",
-      "rosary_beads"
+      "regional_indicator_symbol_n"
     ],
-    "tags": []
+    "emoji": "🇳",
+    "description": "regional indicator symbol letter n",
+    "tags": [
+      "letter",
+      "n"
+    ]
   },
   {
-    "emoji": "☠",
-    "description": "skull and crossbones",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "skull_crossbones"
+      "bullettrain_front"
     ],
-    "tags": []
+    "description": "high-speed train with bullet nose",
+    "tags": [
+      "train"
+    ],
+    "emoji": "🚅"
   },
   {
-    "emoji": "🤖",
-    "description": "robot face",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "robot_face",
-      "bot_face"
+      "wastebasket"
     ],
-    "tags": []
+    "supports_fitzpatrick": false,
+    "description": "wastebasket",
+    "tags": [],
+    "emoji": "🗑"
   },
   {
-    "emoji": "🦁",
-    "description": "lion face",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "lion_face",
-      "cute_lion",
-      "timid_lion"
+      "regional_indicator_symbol_k"
     ],
-    "tags": []
+    "emoji": "🇰",
+    "description": "regional indicator symbol letter k",
+    "tags": [
+      "letter",
+      "k"
+    ]
   },
   {
-    "emoji": "🦄",
-    "description": "unicorn face",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "unicorn_face"
+      "spiral_calendar_pad"
     ],
-    "tags": []
+    "supports_fitzpatrick": false,
+    "description": "spiral calendar pad",
+    "tags": [],
+    "emoji": "🗓"
   },
   {
-    "emoji": "🐿",
-    "description": "chipmunk",
+    "aliases": [
+      "bullettrain_side"
+    ],
+    "description": "high-speed train",
+    "tags": [
+      "train"
+    ],
+    "emoji": "🚄"
+  },
+  {
+    "aliases": [
+      "old_key"
+    ],
     "supports_fitzpatrick": false,
+    "description": "an ornate old key",
+    "tags": [],
+    "emoji": "🗝"
+  },
+  {
+    "aliases": [
+      "compression"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "compression",
+    "tags": [],
+    "emoji": "🗜"
+  },
+  {
+    "aliases": [
+      "regional_indicator_symbol_d"
+    ],
+    "emoji": "🇩",
+    "description": "regional indicator symbol letter d",
+    "tags": [
+      "letter",
+      "d"
+    ]
+  },
+  {
+    "aliases": [
+      "white_circle"
+    ],
+    "description": "medium white circle",
+    "tags": [],
+    "emoji": "⚪"
+  },
+  {
+    "aliases": [
+      "metro"
+    ],
+    "description": "metro",
+    "tags": [],
+    "emoji": "🚇"
+  },
+  {
+    "aliases": [
+      "bike"
+    ],
+    "description": "bicycle",
+    "tags": [
+      "bicycle"
+    ],
+    "emoji": "🚲"
+  },
+  {
+    "aliases": [
+      "flag-va"
+    ],
+    "description": "regional indicator symbol letters va",
+    "tags": [],
+    "emoji": "🇻🇦"
+  },
+  {
+    "aliases": [
+      "children_crossing"
+    ],
+    "description": "children crossing",
+    "tags": [],
+    "emoji": "🚸"
+  },
+  {
+    "aliases": [
+      "mahjong"
+    ],
+    "description": "mahjong tile red dragon",
+    "tags": [],
+    "emoji": "🀄"
+  },
+  {
+    "aliases": [
+      "train2"
+    ],
+    "description": "train",
+    "tags": [],
+    "emoji": "🚆"
+  },
+  {
+    "aliases": [
+      "card_file_box"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "card file box",
+    "tags": [],
+    "emoji": "🗃"
+  },
+  {
+    "aliases": [
+      "regional_indicator_symbol_z"
+    ],
+    "emoji": "🇿",
+    "description": "regional indicator symbol letter z",
+    "tags": [
+      "letter",
+      "z"
+    ]
+  },
+  {
+    "aliases": [
+      "helicopter"
+    ],
+    "description": "helicopter",
+    "tags": [],
+    "emoji": "🚁"
+  },
+  {
     "aliases": [
       "chipmunk",
       "squirrel"
     ],
-    "tags": []
-  },
-  {
-    "emoji": "🦃",
-    "description": "turkey",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "turkey"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🕊",
-    "description": "dove of peace, carrying an olive branch",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "dove",
-      "dove_peace"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🦀",
-    "description": "red crab",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "crab",
-      "cancer"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🕷",
-    "description": "black spider with eight legs",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "spider"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🕸",
-    "description": "spider web in orb form",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "spider_web",
-      "cobweb"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🦂",
-    "description": "scorpion",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "scorpion"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🏵",
-    "description": "rosette",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "rosette"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "☘",
-    "description": "shamrock",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "shamrock",
-      "st_patrick"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🌶",
-    "description": "hot pepper",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "hot_pepper",
-      "chili_pepper",
-      "spice",
-      "spicy"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🧀",
-    "description": "cheese wedge",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "cheese"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🌭",
-    "description": "hot dog",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "hot_dog"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🌮",
-    "description": "taco",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "taco"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🌯",
-    "description": "burrito",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "burrito",
-      "wrap"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🍿",
-    "description": "popcorn",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "popcorn"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🍾",
-    "description": "bottle with popping cork",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "champagne",
-      "sparkling_wine"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🍽",
-    "description": "fork and knife with plate",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "fork_knife_plate"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🏺",
-    "description": "amphora",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "amphora",
-      "jar",
-      "vase"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🗺",
-    "description": "world map",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "world_map"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🏔",
-    "description": "snow capped mountain",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "snow_capped_mountain",
-      "mont_fuji"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "⛰",
-    "description": "mountain",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "mountain"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🏕",
-    "description": "camping with tent and tree",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "camping",
-      "campsite",
-      "tent"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🏖",
-    "description": "beach with umbrella",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "breach"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🏜",
-    "description": "desert with cactus",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "desert"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🏝",
-    "description": "desert island with palm tree",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "desert_island"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🏞",
-    "description": "national park",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "national_park"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🏟",
-    "description": "stadium",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "stadium"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🏛",
-    "description": "classical building",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "classical_building"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🏗",
-    "description": "building in construction with crane",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "building_construction",
-      "crane"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🏘",
-    "description": "house buildings",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "house_buildings",
-      "multiple_houses"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🏙",
-    "description": "cityscape",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "cityscape"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🏚",
-    "description": "derelict house",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "derelict_house",
-      "old_house",
-      "abandoned_house"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🛐",
-    "description": "place of worship",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "worship_building",
-      "worship_place",
-      "religious_building",
-      "religious_place"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🕋",
-    "description": "kaaba",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "kaaba",
-      "mecca"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🕌",
-    "description": "mosque with domed roof and minaret",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "mosque",
-      "minaret",
-      "domed_roof"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🕍",
-    "description": "synagogue with star of David",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "synagogue",
-      "temple",
-      "jewish"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🖼",
-    "description": "frame with picture or painting",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "picture_frame",
-      "painting",
-      "gallery"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🛢",
-    "description": "oil drum",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "oil_drum"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🛣",
-    "description": "motorway",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "motorway",
-      "highway",
-      "road",
-      "interstate",
-      "freeway"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🛤",
-    "description": "railway track",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "railway_track"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🛳",
-    "description": "passenger ship",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "passenger_ship"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "⛴",
-    "description": "ferry",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "ferry"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🛥",
-    "description": "motor boat",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "motor_boat"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🛩",
-    "description": "small airplane",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "small_airplane"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🛫",
-    "description": "airplane departure",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "airplane_departure",
-      "take_off"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🛬",
-    "description": "airplane arriving",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "airplane_arriving",
-      "airplane_arrival",
-      "landing"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🛰",
-    "description": "satellite",
     "supports_fitzpatrick": false,
-    "aliases": [
-      "satellite"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🛎",
-    "description": "bellhop bell",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "bellhop_bell"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🛌",
-    "description": "sleeping accommodation",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "sleeping_accommodation"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🛏",
-    "description": "bed or bedroom",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "bed",
-      "bedroom"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🛋",
-    "description": "couch and lamp",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "couch_lamp",
-      "couch",
-      "sofa",
-      "lounge"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "⏱",
-    "description": "stopwatch",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "stopwatch"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "⏲",
-    "description": "timer clock",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "timer_clock"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🕰",
-    "description": "mantelpiece clock",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "mantelpiece_clock"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🌡",
-    "description": "thermometer",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "thermometer",
-      "hot_weather",
-      "temperature"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "⛈",
-    "description": "thunder cloud and rain",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "thunder_cloud_rain"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🌤",
-    "description": "white sun with small cloud",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "white_sun_small_cloud"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🌥",
-    "description": "white sun behind cloud",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "white_sun_behind_cloud"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🌦",
-    "description": "white sun behind cloud with rain",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "white_sun_behind_cloud_rain"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🌧",
-    "description": "cloud with rain",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "cloud_rain"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🌨",
-    "description": "cloud with snow",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "cloud_snow"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🌩",
-    "description": "cloud with lightning",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "cloud_lightning"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🌪",
-    "description": "cloud with tornado",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "cloud_tornado"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🌫",
-    "description": "fog",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "fog"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🌬",
-    "description": "wind blowing face",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "wind_blowing_face",
-      "mother_nature",
-      "blowing_wind"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "☂",
-    "description": "open umbrella",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "open_umbrella"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "⛱",
-    "description": "umbrella planted on the ground",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "planted_umbrella",
-      "umbrella_on_ground"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "☃",
-    "description": "snowman with snow",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "snowman_with_snow",
-      "snowing_snowman"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "☄",
-    "description": "comet",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "comet",
-      "light_beam",
-      "blue_beam"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🕎",
-    "description": "menorah with nine branches",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "menorah",
-      "candelabrum",
-      "chanukiah"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🎖",
-    "description": "military medal with ribbon",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "military_medal",
-      "military_decoration"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🎗",
-    "description": "reminder ribbon",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "reminder_ribbon",
-      "awareness_ribbon"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🎞",
-    "description": "film frames",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "film_frames"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🎟",
-    "description": "admission ticket",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "admission_ticket"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🏷",
-    "description": "label",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "label"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🏌",
-    "description": "golfer swinging a golf club",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "golfer",
-      "golf_club"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "⛸",
-    "description": "single ice skate",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "ice_skate",
-      "ice_skating"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "⛷",
-    "description": "skier",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "skier"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "⛹",
-    "description": "person with ball",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "person_with_ball"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🏋",
-    "description": "weight lifter",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "weight_lifter"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🏎",
-    "description": "racing car",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "racing_car",
-      "formula_one",
-      "f1"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🏍",
-    "description": "racing motorcycle",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "racing_motorcycle",
-      "motorcycle",
-      "motorbike"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🏅",
-    "description": "sports medal",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "sports_medal",
-      "sports_decoration"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🏏",
-    "description": "cricket bat and ball",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "cricket"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🏐",
-    "description": "volleyball",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "volleyball"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🏑",
-    "description": "field hockey stick and ball",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "field_hockey"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🏒",
-    "description": "ice hockey stick and puck",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "ice_hockey"
-    ],
-    "tags": []
+    "description": "chipmunk",
+    "tags": [],
+    "emoji": "🐿"
   },
   {
-    "emoji": "🏓",
-    "description": "table tennis paddle and ball",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "table_tennis",
-      "ping_pong"
+      "rocket"
     ],
-    "tags": []
-  },
-  {
-    "emoji": "🏸",
-    "description": "badminton racket and shuttlecock",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "badminton"
+    "description": "rocket",
+    "tags": [
+      "ship",
+      "launch"
     ],
-    "tags": []
+    "emoji": "🚀"
   },
   {
-    "emoji": "🕹",
-    "description": "joystick",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "joystick"
+      "regional_indicator_symbol_x"
     ],
-    "tags": []
+    "emoji": "🇽",
+    "description": "regional indicator symbol letter x",
+    "tags": [
+      "letter",
+      "x"
+    ]
   },
   {
-    "emoji": "⏭",
-    "description": "black right-pointing double triangle with vertical bar",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "black_right_pointing_double_triangle_with_vertical_bar"
+      "three_button_mouse",
+      "computer_mouse"
     ],
-    "tags": []
-  },
-  {
-    "emoji": "⏯",
-    "description": "black right-pointing triangle with double vertical bar",
     "supports_fitzpatrick": false,
-    "aliases": [
-      "black_right_pointing_triangle_with_double_vertical_bar"
-    ],
-    "tags": []
+    "description": "three button mouse",
+    "tags": [],
+    "emoji": "🖱"
   },
   {
-    "emoji": "⏮",
-    "description": "black left-pointing double triangle with vertical bar",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "black_left_pointing_double_triangle_with_vertical_bar"
+      "railway_car"
     ],
-    "tags": []
+    "description": "railway car",
+    "tags": [],
+    "emoji": "🚃"
   },
   {
-    "emoji": "⏸",
-    "description": "double vertical bar",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "double_vertical_bar"
+      "free"
     ],
-    "tags": []
+    "description": "squared free",
+    "tags": [],
+    "emoji": "🆓"
   },
   {
-    "emoji": "⏹",
-    "description": "black square for stop",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "black_square_for_stop"
+      "trackball"
     ],
-    "tags": []
-  },
-  {
-    "emoji": "⏺",
-    "description": "black circle for record",
     "supports_fitzpatrick": false,
-    "aliases": [
-      "black_circle_for_record"
-    ],
-    "tags": []
+    "description": "trackball",
+    "tags": [],
+    "emoji": "🖲"
   },
   {
-    "emoji": "🎙",
-    "description": "studio microphone",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "studio_microphone"
+      "regional_indicator_symbol_u"
     ],
-    "tags": []
+    "emoji": "🇺",
+    "description": "regional indicator symbol letter u",
+    "tags": [
+      "letter",
+      "u"
+    ]
   },
   {
-    "emoji": "🎚",
-    "description": "level slider",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "level_slider"
+      "steam_locomotive"
     ],
-    "tags": []
-  },
-  {
-    "emoji": "🎛",
-    "description": "control knobs",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "control_knobs"
+    "description": "steam locomotive",
+    "tags": [
+      "train"
     ],
-    "tags": []
+    "emoji": "🚂"
   },
   {
-    "emoji": "*⃣",
-    "description": "keycap asterisk",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "keycap_asterisk",
-      "star_keycap"
+      "regional_indicator_symbol_v"
     ],
-    "tags": []
+    "emoji": "🇻",
+    "description": "regional indicator symbol letter v",
+    "tags": [
+      "letter",
+      "v"
+    ]
   },
   {
-    "emoji": "🖥",
-    "description": "desktop computer",
-    "supports_fitzpatrick": false,
     "aliases": [
       "desktop_computer",
       "pc_tower",
       "imac"
     ],
-    "tags": []
+    "supports_fitzpatrick": false,
+    "description": "desktop computer",
+    "tags": [],
+    "emoji": "🖥"
   },
   {
-    "emoji": "🖨",
-    "description": "printer",
+    "aliases": [
+      "oncoming_bus"
+    ],
+    "description": "oncoming bus",
+    "tags": [],
+    "emoji": "🚍"
+  },
+  {
+    "aliases": [
+      "flag-nr"
+    ],
+    "description": "regional indicator symbol letters nr",
+    "tags": [],
+    "emoji": "🇳🇷"
+  },
+  {
+    "aliases": [
+      "regional_indicator_symbol_s"
+    ],
+    "emoji": "🇸",
+    "description": "regional indicator symbol letter s",
+    "tags": [
+      "letter",
+      "s"
+    ]
+  },
+  {
+    "aliases": [
+      "bus"
+    ],
+    "description": "bus",
+    "tags": [],
+    "emoji": "🚌"
+  },
+  {
+    "aliases": [
+      "regional_indicator_symbol_t"
+    ],
+    "emoji": "🇹",
+    "description": "regional indicator symbol letter t",
+    "tags": [
+      "letter",
+      "t"
+    ]
+  },
+  {
+    "aliases": [
+      "busstop"
+    ],
+    "description": "bus stop",
+    "tags": [],
+    "emoji": "🚏"
+  },
+  {
+    "aliases": [
+      "middle_finger",
+      "reversed_hand_with_middle_finger_extended"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "reversed hand with middle finger extended",
+    "tags": [],
+    "emoji": "🖕"
+  },
+  {
+    "aliases": [
+      "lk",
+      "flag-lk"
+    ],
+    "emoji": "🇱🇰",
+    "description": "regional indicator symbol letter l + regional indicator symbol letter k",
+    "tags": [
+      "flag",
+      "sri lanka"
+    ]
+  },
+  {
+    "aliases": [
+      "pineapple"
+    ],
+    "description": "pineapple",
+    "tags": [],
+    "emoji": "🍍"
+  },
+  {
+    "aliases": [
+      "hearts"
+    ],
+    "description": "black heart suit",
+    "tags": [],
+    "emoji": "♥"
+  },
+  {
+    "aliases": [
+      "splayed_hand",
+      "raised_hand_with_fingers_splayed"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "raised hand with five fingers splayed",
+    "tags": [],
+    "emoji": "🖐"
+  },
+  {
+    "aliases": [
+      "regional_indicator_symbol_b"
+    ],
+    "emoji": "🇧",
+    "description": "regional indicator symbol letter b",
+    "tags": [
+      "letter",
+      "b"
+    ]
+  },
+  {
+    "aliases": [
+      "station"
+    ],
+    "description": "station",
+    "tags": [],
+    "emoji": "🚉"
+  },
+  {
+    "aliases": [
+      "church"
+    ],
+    "description": "church",
+    "tags": [],
+    "emoji": "⛪"
+  },
+  {
+    "aliases": [
+      "arrow_double_down"
+    ],
+    "description": "black down-pointing double triangle",
+    "tags": [],
+    "emoji": "⏬"
+  },
+  {
+    "aliases": [
+      "light_rail"
+    ],
+    "description": "light rail",
+    "tags": [],
+    "emoji": "🚈"
+  },
+  {
+    "aliases": [
+      "satellite"
+    ],
     "supports_fitzpatrick": false,
+    "description": "satellite",
+    "tags": [],
+    "emoji": "🛰"
+  },
+  {
+    "aliases": [
+      "linked_paperclips"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "multiple paperclips linked together",
+    "tags": [],
+    "emoji": "🖇"
+  },
+  {
+    "aliases": [
+      "train"
+    ],
+    "description": "tram car",
+    "tags": [],
+    "emoji": "🚋"
+  },
+  {
+    "aliases": [
+      "lower_left_crayon"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "lower left crayon",
+    "tags": [],
+    "emoji": "🖍"
+  },
+  {
+    "aliases": [
+      "lower_left_paintbrush"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "lower left paintbrush",
+    "tags": [],
+    "emoji": "🖌"
+  },
+  {
+    "aliases": [
+      "tent"
+    ],
+    "description": "tent",
+    "tags": [
+      "camping"
+    ],
+    "emoji": "⛺"
+  },
+  {
+    "aliases": [
+      "man-woman-girl-boy"
+    ],
+    "description": "",
+    "tags": [],
+    "emoji": "👨‍👩‍👧‍👦"
+  },
+  {
+    "aliases": [
+      "flag-br",
+      "br"
+    ],
+    "emoji": "🇧🇷",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter r",
+    "tags": [
+      "flag",
+      "brazil"
+    ]
+  },
+  {
+    "aliases": [
+      "lower_left_ballpoint_pen"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "lower left ballpoint pen",
+    "tags": [],
+    "emoji": "🖊"
+  },
+  {
+    "aliases": [
+      "notes"
+    ],
+    "description": "multiple musical notes",
+    "tags": [
+      "music"
+    ],
+    "emoji": "🎶"
+  },
+  {
+    "aliases": [
+      "saxophone"
+    ],
+    "description": "saxophone",
+    "tags": [],
+    "emoji": "🎷"
+  },
+  {
+    "aliases": [
+      "flower_playing_cards"
+    ],
+    "description": "flower playing cards",
+    "tags": [],
+    "emoji": "🎴"
+  },
+  {
+    "aliases": [
+      "musical_note"
+    ],
+    "description": "musical note",
+    "tags": [],
+    "emoji": "🎵"
+  },
+  {
+    "aliases": [
+      "game_die"
+    ],
+    "description": "game die",
+    "tags": [
+      "dice",
+      "gambling"
+    ],
+    "emoji": "🎲"
+  },
+  {
+    "aliases": [
+      "bowling"
+    ],
+    "description": "bowling",
+    "tags": [],
+    "emoji": "🎳"
+  },
+  {
+    "aliases": [
+      "slot_machine"
+    ],
+    "description": "slot machine",
+    "tags": [],
+    "emoji": "🎰"
+  },
+  {
+    "aliases": [
+      "8ball"
+    ],
+    "description": "billiards",
+    "tags": [
+      "pool",
+      "billiards"
+    ],
+    "emoji": "🎱"
+  },
+  {
+    "aliases": [
+      "tennis"
+    ],
+    "description": "tennis racquet and ball",
+    "tags": [
+      "sports"
+    ],
+    "emoji": "🎾"
+  },
+  {
+    "aliases": [
+      "ski"
+    ],
+    "description": "ski and ski boot",
+    "tags": [],
+    "emoji": "🎿"
+  },
+  {
+    "aliases": [
+      "musical_score"
+    ],
+    "description": "musical score",
+    "tags": [],
+    "emoji": "🎼"
+  },
+  {
+    "aliases": [
+      "running_shirt_with_sash"
+    ],
+    "description": "running shirt with sash",
+    "tags": [
+      "marathon"
+    ],
+    "emoji": "🎽"
+  },
+  {
+    "aliases": [
+      "trumpet"
+    ],
+    "description": "trumpet",
+    "tags": [],
+    "emoji": "🎺"
+  },
+  {
+    "aliases": [
+      "violin"
+    ],
+    "description": "violin",
+    "tags": [],
+    "emoji": "🎻"
+  },
+  {
+    "aliases": [
+      "guitar"
+    ],
+    "description": "guitar",
+    "tags": [
+      "rock"
+    ],
+    "emoji": "🎸"
+  },
+  {
+    "aliases": [
+      "musical_keyboard"
+    ],
+    "description": "musical keyboard",
+    "tags": [
+      "piano"
+    ],
+    "emoji": "🎹"
+  },
+  {
+    "aliases": [
+      "cinema"
+    ],
+    "description": "cinema",
+    "tags": [
+      "film",
+      "movie"
+    ],
+    "emoji": "🎦"
+  },
+  {
+    "aliases": [
+      "headphones"
+    ],
+    "description": "headphone",
+    "tags": [
+      "music",
+      "earphones"
+    ],
+    "emoji": "🎧"
+  },
+  {
+    "aliases": [
+      "microphone"
+    ],
+    "description": "microphone",
+    "tags": [
+      "sing"
+    ],
+    "emoji": "🎤"
+  },
+  {
+    "aliases": [
+      "movie_camera"
+    ],
+    "description": "movie camera",
+    "tags": [
+      "film",
+      "video"
+    ],
+    "emoji": "🎥"
+  },
+  {
+    "aliases": [
+      "roller_coaster"
+    ],
+    "description": "roller coaster",
+    "tags": [],
+    "emoji": "🎢"
+  },
+  {
+    "aliases": [
+      "fishing_pole_and_fish"
+    ],
+    "description": "fishing pole and fish",
+    "tags": [],
+    "emoji": "🎣"
+  },
+  {
+    "aliases": [
+      "carousel_horse"
+    ],
+    "description": "carousel horse",
+    "tags": [],
+    "emoji": "🎠"
+  },
+  {
+    "aliases": [
+      "ferris_wheel"
+    ],
+    "description": "ferris wheel",
+    "tags": [],
+    "emoji": "🎡"
+  },
+  {
+    "aliases": [
+      "video_game"
+    ],
+    "description": "video game",
+    "tags": [
+      "play",
+      "controller",
+      "console"
+    ],
+    "emoji": "🎮"
+  },
+  {
+    "aliases": [
+      "dart"
+    ],
+    "description": "direct hit",
+    "tags": [
+      "target"
+    ],
+    "emoji": "🎯"
+  },
+  {
+    "aliases": [
+      "clapper"
+    ],
+    "description": "clapper board",
+    "tags": [
+      "film"
+    ],
+    "emoji": "🎬"
+  },
+  {
+    "aliases": [
+      "performing_arts"
+    ],
+    "description": "performing arts",
+    "tags": [
+      "theater",
+      "drama"
+    ],
+    "emoji": "🎭"
+  },
+  {
+    "aliases": [
+      "circus_tent"
+    ],
+    "description": "circus tent",
+    "tags": [],
+    "emoji": "🎪"
+  },
+  {
+    "aliases": [
+      "ticket"
+    ],
+    "description": "ticket",
+    "tags": [],
+    "emoji": "🎫"
+  },
+  {
+    "aliases": [
+      "art"
+    ],
+    "description": "artist palette",
+    "tags": [
+      "design",
+      "paint"
+    ],
+    "emoji": "🎨"
+  },
+  {
+    "aliases": [
+      "tophat"
+    ],
+    "description": "top hat",
+    "tags": [
+      "hat",
+      "classy"
+    ],
+    "emoji": "🎩"
+  },
+  {
+    "aliases": [
+      "military_medal",
+      "medal",
+      "military_decoration"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "military medal with ribbon",
+    "tags": [],
+    "emoji": "🎖"
+  },
+  {
+    "aliases": [
+      "reminder_ribbon",
+      "awareness_ribbon"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "reminder ribbon",
+    "tags": [],
+    "emoji": "🎗"
+  },
+  {
+    "aliases": [
+      "tm"
+    ],
+    "description": "trade mark sign",
+    "tags": [
+      "trademark"
+    ],
+    "emoji": "™"
+  },
+  {
+    "aliases": [
+      "school_satchel"
+    ],
+    "description": "school satchel",
+    "tags": [],
+    "emoji": "🎒"
+  },
+  {
+    "aliases": [
+      "mortar_board"
+    ],
+    "description": "graduation cap",
+    "tags": [
+      "education",
+      "college",
+      "university",
+      "graduation"
+    ],
+    "emoji": "🎓"
+  },
+  {
+    "aliases": [
+      "wind_chime"
+    ],
+    "description": "wind chime",
+    "tags": [],
+    "emoji": "🎐"
+  },
+  {
+    "aliases": [
+      "rice_scene"
+    ],
+    "description": "moon viewing ceremony",
+    "tags": [],
+    "emoji": "🎑"
+  },
+  {
+    "aliases": [
+      "film_frames"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "film frames",
+    "tags": [],
+    "emoji": "🎞"
+  },
+  {
+    "aliases": [
+      "regional_indicator_symbol_e"
+    ],
+    "emoji": "🇪",
+    "description": "regional indicator symbol letter e",
+    "tags": [
+      "letter",
+      "e"
+    ]
+  },
+  {
+    "aliases": [
+      "popcorn"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "popcorn",
+    "tags": [],
+    "emoji": "🍿"
+  },
+  {
+    "aliases": [
+      "level_slider"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "level slider",
+    "tags": [],
+    "emoji": "🎚"
+  },
+  {
+    "aliases": [
+      "potable_water"
+    ],
+    "description": "potable water symbol",
+    "tags": [],
+    "emoji": "🚰"
+  },
+  {
+    "aliases": [
+      "regional_indicator_symbol_f"
+    ],
+    "emoji": "🇫",
+    "description": "regional indicator symbol letter f",
+    "tags": [
+      "letter",
+      "f"
+    ]
+  },
+  {
+    "aliases": [
+      "no_good"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "face with no good gesture",
+    "tags": [
+      "stop",
+      "halt"
+    ],
+    "emoji": "🙅"
+  },
+  {
+    "aliases": [
+      "sparkler"
+    ],
+    "description": "firework sparkler",
+    "tags": [],
+    "emoji": "🎇"
+  },
+  {
+    "aliases": [
+      "bow"
+    ],
+    "description": "person bowing deeply",
+    "tags": [
+      "respect",
+      "thanks"
+    ],
+    "emoji": "🙇"
+  },
+  {
+    "aliases": [
+      "santa"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "father christmas",
+    "tags": [
+      "christmas"
+    ],
+    "emoji": "🎅"
+  },
+  {
+    "aliases": [
+      "birthday"
+    ],
+    "description": "birthday cake",
+    "tags": [
+      "party"
+    ],
+    "emoji": "🎂"
+  },
+  {
+    "aliases": [
+      "scream_cat"
+    ],
+    "description": "weary cat face",
+    "tags": [
+      "horror"
+    ],
+    "emoji": "🙀"
+  },
+  {
+    "aliases": [
+      "ribbon"
+    ],
+    "description": "ribbon",
+    "tags": [],
+    "emoji": "🎀"
+  },
+  {
+    "aliases": [
+      "gift"
+    ],
+    "description": "wrapped present",
+    "tags": [
+      "present",
+      "birthday",
+      "christmas"
+    ],
+    "emoji": "🎁"
+  },
+  {
+    "aliases": [
+      "dolls"
+    ],
+    "description": "japanese dolls",
+    "tags": [],
+    "emoji": "🎎"
+  },
+  {
+    "aliases": [
+      "raised_hands"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "person raising both hands in celebration",
+    "tags": [
+      "hooray"
+    ],
+    "emoji": "🙌"
+  },
+  {
+    "aliases": [
+      "pray"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "person with folded hands",
+    "tags": [
+      "please",
+      "hope",
+      "wish"
+    ],
+    "emoji": "🙏"
+  },
+  {
+    "aliases": [
+      "bamboo"
+    ],
+    "description": "pine decoration",
+    "tags": [],
+    "emoji": "🎍"
+  },
+  {
+    "aliases": [
+      "hear_no_evil"
+    ],
+    "description": "hear-no-evil monkey",
+    "tags": [
+      "monkey",
+      "deaf"
+    ],
+    "emoji": "🙉"
+  },
+  {
+    "aliases": [
+      "see_no_evil"
+    ],
+    "description": "see-no-evil monkey",
+    "tags": [
+      "monkey",
+      "blind",
+      "ignore"
+    ],
+    "emoji": "🙈"
+  },
+  {
+    "aliases": [
+      "raising_hand"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "happy person raising one hand",
+    "tags": [],
+    "emoji": "🙋"
+  },
+  {
+    "aliases": [
+      "speak_no_evil"
+    ],
+    "description": "speak-no-evil monkey",
+    "tags": [
+      "monkey",
+      "mute",
+      "hush"
+    ],
+    "emoji": "🙊"
+  },
+  {
+    "aliases": [
+      "dizzy_face"
+    ],
+    "description": "dizzy face",
+    "tags": [],
+    "emoji": "😵"
+  },
+  {
+    "aliases": [
+      "sleeping"
+    ],
+    "description": "sleeping face",
+    "tags": [
+      "zzz"
+    ],
+    "emoji": "😴"
+  },
+  {
+    "aliases": [
+      "mask"
+    ],
+    "description": "face with medical mask",
+    "tags": [
+      "sick",
+      "ill"
+    ],
+    "emoji": "😷"
+  },
+  {
+    "aliases": [
+      "no_mouth"
+    ],
+    "description": "face without mouth",
+    "tags": [
+      "mute",
+      "silence"
+    ],
+    "emoji": "😶"
+  },
+  {
+    "aliases": [
+      "scream"
+    ],
+    "description": "face screaming in fear",
+    "tags": [
+      "horror",
+      "shocked"
+    ],
+    "emoji": "😱"
+  },
+  {
+    "aliases": [
+      "cold_sweat"
+    ],
+    "description": "face with open mouth and cold sweat",
+    "tags": [
+      "nervous"
+    ],
+    "emoji": "😰"
+  },
+  {
+    "aliases": [
+      "flushed"
+    ],
+    "description": "flushed face",
+    "tags": [],
+    "emoji": "😳"
+  },
+  {
+    "aliases": [
+      "astonished"
+    ],
+    "description": "astonished face",
+    "tags": [
+      "amazed",
+      "gasp"
+    ],
+    "emoji": "😲"
+  },
+  {
+    "aliases": [
+      "kissing_cat"
+    ],
+    "description": "kissing cat face with closed eyes",
+    "tags": [],
+    "emoji": "😽"
+  },
+  {
+    "aliases": [
+      "smirk_cat"
+    ],
+    "description": "cat face with wry smile",
+    "tags": [],
+    "emoji": "😼"
+  },
+  {
+    "aliases": [
+      "crying_cat_face"
+    ],
+    "description": "crying cat face",
+    "tags": [
+      "sad",
+      "tear"
+    ],
+    "emoji": "😿"
+  },
+  {
+    "aliases": [
+      "pouting_cat"
+    ],
+    "description": "pouting cat face",
+    "tags": [],
+    "emoji": "😾"
+  },
+  {
+    "aliases": [
+      "joy_cat"
+    ],
+    "description": "cat face with tears of joy",
+    "tags": [],
+    "emoji": "😹"
+  },
+  {
+    "aliases": [
+      "smile_cat"
+    ],
+    "description": "grinning cat face with smiling eyes",
+    "tags": [],
+    "emoji": "😸"
+  },
+  {
+    "aliases": [
+      "heart_eyes_cat"
+    ],
+    "description": "smiling cat face with heart-shaped eyes",
+    "tags": [],
+    "emoji": "😻"
+  },
+  {
+    "aliases": [
+      "smiley_cat"
+    ],
+    "description": "smiling cat face with open mouth",
+    "tags": [],
+    "emoji": "😺"
+  },
+  {
+    "aliases": [
+      "disappointed_relieved"
+    ],
+    "description": "disappointed but relieved face",
+    "tags": [
+      "phew",
+      "sweat",
+      "nervous"
+    ],
+    "emoji": "😥"
+  },
+  {
+    "aliases": [
+      "triumph"
+    ],
+    "description": "face with look of triumph",
+    "tags": [
+      "smug"
+    ],
+    "emoji": "😤"
+  },
+  {
+    "aliases": [
+      "anguished"
+    ],
+    "description": "anguished face",
+    "tags": [
+      "stunned"
+    ],
+    "emoji": "😧"
+  },
+  {
+    "aliases": [
+      "frowning"
+    ],
+    "description": "frowning face with open mouth",
+    "tags": [],
+    "emoji": "😦"
+  },
+  {
+    "aliases": [
+      "rage"
+    ],
+    "description": "pouting face",
+    "tags": [
+      "angry"
+    ],
+    "emoji": "😡"
+  },
+  {
+    "aliases": [
+      "angry"
+    ],
+    "description": "angry face",
+    "tags": [
+      "mad",
+      "annoyed"
+    ],
+    "emoji": "😠"
+  },
+  {
+    "aliases": [
+      "persevere"
+    ],
+    "description": "persevering face",
+    "tags": [
+      "struggling"
+    ],
+    "emoji": "😣"
+  },
+  {
+    "aliases": [
+      "cry"
+    ],
+    "description": "crying face",
+    "tags": [
+      "sad",
+      "tear"
+    ],
+    "emoji": "😢"
+  },
+  {
+    "aliases": [
+      "sob"
+    ],
+    "description": "loudly crying face",
+    "tags": [
+      "sad",
+      "cry",
+      "bawling"
+    ],
+    "emoji": "😭"
+  },
+  {
+    "aliases": [
+      "grimacing"
+    ],
+    "description": "grimacing face",
+    "tags": [],
+    "emoji": "😬"
+  },
+  {
+    "aliases": [
+      "hushed"
+    ],
+    "description": "hushed face",
+    "tags": [
+      "silence",
+      "speechless"
+    ],
+    "emoji": "😯"
+  },
+  {
+    "aliases": [
+      "open_mouth"
+    ],
+    "description": "face with open mouth",
+    "tags": [
+      "surprise",
+      "impressed",
+      "wow"
+    ],
+    "emoji": "😮"
+  },
+  {
+    "aliases": [
+      "weary"
+    ],
+    "description": "weary face",
+    "tags": [
+      "tired"
+    ],
+    "emoji": "😩"
+  },
+  {
+    "aliases": [
+      "fearful"
+    ],
+    "description": "fearful face",
+    "tags": [
+      "scared",
+      "shocked",
+      "oops"
+    ],
+    "emoji": "😨"
+  },
+  {
+    "aliases": [
+      "tired_face"
+    ],
+    "description": "tired face",
+    "tags": [
+      "upset",
+      "whine"
+    ],
+    "emoji": "😫"
+  },
+  {
+    "aliases": [
+      "sleepy"
+    ],
+    "description": "sleepy face",
+    "tags": [
+      "tired"
+    ],
+    "emoji": "😪"
+  },
+  {
+    "aliases": [
+      "confused"
+    ],
+    "description": "confused face",
+    "tags": [],
+    "emoji": "😕"
+  },
+  {
+    "aliases": [
+      "pensive"
+    ],
+    "description": "pensive face",
+    "tags": [],
+    "emoji": "😔"
+  },
+  {
+    "aliases": [
+      "kissing"
+    ],
+    "description": "kissing face",
+    "tags": [],
+    "emoji": "😗"
+  },
+  {
+    "aliases": [
+      "confounded"
+    ],
+    "description": "confounded face",
+    "tags": [],
+    "emoji": "😖"
+  },
+  {
+    "aliases": [
+      "expressionless"
+    ],
+    "description": "expressionless face",
+    "tags": [],
+    "emoji": "😑"
+  },
+  {
+    "aliases": [
+      "neutral_face"
+    ],
+    "description": "neutral face",
+    "tags": [
+      "meh"
+    ],
+    "emoji": "😐"
+  },
+  {
+    "aliases": [
+      "sweat"
+    ],
+    "description": "face with cold sweat",
+    "tags": [],
+    "emoji": "😓"
+  },
+  {
+    "aliases": [
+      "unamused"
+    ],
+    "description": "unamused face",
+    "tags": [
+      "meh"
+    ],
+    "emoji": "😒"
+  },
+  {
+    "aliases": [
+      "stuck_out_tongue_closed_eyes"
+    ],
+    "description": "face with stuck-out tongue and tightly-closed eyes",
+    "tags": [
+      "prank"
+    ],
+    "emoji": "😝"
+  },
+  {
+    "aliases": [
+      "stuck_out_tongue_winking_eye"
+    ],
+    "description": "face with stuck-out tongue and winking eye",
+    "tags": [
+      "prank",
+      "silly"
+    ],
+    "emoji": "😜"
+  },
+  {
+    "aliases": [
+      "worried"
+    ],
+    "description": "worried face",
+    "tags": [
+      "nervous"
+    ],
+    "emoji": "😟"
+  },
+  {
+    "aliases": [
+      "disappointed"
+    ],
+    "description": "disappointed face",
+    "tags": [
+      "sad"
+    ],
+    "emoji": "😞"
+  },
+  {
+    "aliases": [
+      "kissing_smiling_eyes"
+    ],
+    "description": "kissing face with smiling eyes",
+    "tags": [],
+    "emoji": "😙"
+  },
+  {
+    "aliases": [
+      "kissing_heart"
+    ],
+    "description": "face throwing a kiss",
+    "tags": [
+      "flirt"
+    ],
+    "emoji": "😘"
+  },
+  {
+    "aliases": [
+      "stuck_out_tongue"
+    ],
+    "description": "face with stuck-out tongue",
+    "tags": [],
+    "emoji": "😛"
+  },
+  {
+    "aliases": [
+      "kissing_closed_eyes"
+    ],
+    "description": "kissing face with closed eyes",
+    "tags": [],
+    "emoji": "😚"
+  },
+  {
+    "aliases": [
+      "sweat_smile"
+    ],
+    "description": "smiling face with open mouth and cold sweat",
+    "tags": [
+      "hot"
+    ],
+    "emoji": "😅"
+  },
+  {
+    "aliases": [
+      "smile"
+    ],
+    "description": "smiling face with open mouth and smiling eyes",
+    "tags": [
+      "happy",
+      "joy",
+      "pleased"
+    ],
+    "emoji": "😄"
+  },
+  {
+    "aliases": [
+      "innocent"
+    ],
+    "description": "smiling face with halo",
+    "tags": [
+      "angel"
+    ],
+    "emoji": "😇"
+  },
+  {
+    "aliases": [
+      "laughing",
+      "satisfied"
+    ],
+    "description": "smiling face with open mouth and tightly-closed eyes",
+    "tags": [
+      "happy",
+      "haha"
+    ],
+    "emoji": "😆"
+  },
+  {
+    "aliases": [
+      "grin"
+    ],
+    "description": "grinning face with smiling eyes",
+    "tags": [],
+    "emoji": "😁"
+  },
+  {
+    "aliases": [
+      "grinning"
+    ],
+    "description": "grinning face",
+    "tags": [
+      "smile",
+      "happy"
+    ],
+    "emoji": "😀"
+  },
+  {
+    "aliases": [
+      "smiley"
+    ],
+    "description": "smiling face with open mouth",
+    "tags": [
+      "happy",
+      "joy",
+      "haha"
+    ],
+    "emoji": "😃"
+  },
+  {
+    "aliases": [
+      "joy"
+    ],
+    "description": "face with tears of joy",
+    "tags": [
+      "tears"
+    ],
+    "emoji": "😂"
+  },
+  {
+    "aliases": [
+      "heart_eyes"
+    ],
+    "description": "smiling face with heart-shaped eyes",
+    "tags": [
+      "love",
+      "crush"
+    ],
+    "emoji": "😍"
+  },
+  {
+    "aliases": [
+      "relieved"
+    ],
+    "description": "relieved face",
+    "tags": [
+      "whew"
+    ],
+    "emoji": "😌"
+  },
+  {
+    "aliases": [
+      "smirk"
+    ],
+    "description": "smirking face",
+    "tags": [
+      "smug"
+    ],
+    "emoji": "😏"
+  },
+  {
+    "aliases": [
+      "sunglasses"
+    ],
+    "description": "smiling face with sunglasses",
+    "tags": [
+      "cool"
+    ],
+    "emoji": "😎"
+  },
+  {
+    "aliases": [
+      "wink"
+    ],
+    "description": "winking face",
+    "tags": [
+      "flirt"
+    ],
+    "emoji": "😉"
+  },
+  {
+    "aliases": [
+      "smiling_imp"
+    ],
+    "description": "smiling face with horns",
+    "tags": [
+      "devil",
+      "evil",
+      "horns"
+    ],
+    "emoji": "😈"
+  },
+  {
+    "aliases": [
+      "yum"
+    ],
+    "description": "face savouring delicious food",
+    "tags": [
+      "tongue",
+      "lick"
+    ],
+    "emoji": "😋"
+  },
+  {
+    "aliases": [
+      "blush"
+    ],
+    "description": "smiling face with smiling eyes",
+    "tags": [
+      "proud"
+    ],
+    "emoji": "😊"
+  },
+  {
+    "aliases": [
+      "be",
+      "flag-be"
+    ],
+    "emoji": "🇧🇪",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter e",
+    "tags": [
+      "flag",
+      "belgium"
+    ]
+  },
+  {
+    "aliases": [
+      "tulip"
+    ],
+    "description": "tulip",
+    "tags": [
+      "flower"
+    ],
+    "emoji": "🌷"
+  },
+  {
+    "aliases": [
+      "palm_tree"
+    ],
+    "description": "palm tree",
+    "tags": [],
+    "emoji": "🌴"
+  },
+  {
+    "aliases": [
+      "cactus"
+    ],
+    "description": "cactus",
+    "tags": [],
+    "emoji": "🌵"
+  },
+  {
+    "aliases": [
+      "evergreen_tree"
+    ],
+    "description": "evergreen tree",
+    "tags": [
+      "wood"
+    ],
+    "emoji": "🌲"
+  },
+  {
+    "aliases": [
+      "deciduous_tree"
+    ],
+    "description": "deciduous tree",
+    "tags": [
+      "wood"
+    ],
+    "emoji": "🌳"
+  },
+  {
+    "aliases": [
+      "chestnut"
+    ],
+    "description": "chestnut",
+    "tags": [],
+    "emoji": "🌰"
+  },
+  {
+    "aliases": [
+      "seedling"
+    ],
+    "description": "seedling",
+    "tags": [
+      "plant"
+    ],
+    "emoji": "🌱"
+  },
+  {
+    "aliases": [
+      "ear_of_rice"
+    ],
+    "description": "ear of rice",
+    "tags": [],
+    "emoji": "🌾"
+  },
+  {
+    "aliases": [
+      "herb"
+    ],
+    "description": "herb",
+    "tags": [],
+    "emoji": "🌿"
+  },
+  {
+    "aliases": [
+      "blossom"
+    ],
+    "description": "blossom",
+    "tags": [],
+    "emoji": "🌼"
+  },
+  {
+    "aliases": [
+      "corn"
+    ],
+    "description": "ear of maize",
+    "tags": [],
+    "emoji": "🌽"
+  },
+  {
+    "aliases": [
+      "hibiscus"
+    ],
+    "description": "hibiscus",
+    "tags": [],
+    "emoji": "🌺"
+  },
+  {
+    "aliases": [
+      "sunflower"
+    ],
+    "description": "sunflower",
+    "tags": [],
+    "emoji": "🌻"
+  },
+  {
+    "aliases": [
+      "cherry_blossom"
+    ],
+    "description": "cherry blossom",
+    "tags": [
+      "flower",
+      "spring"
+    ],
+    "emoji": "🌸"
+  },
+  {
+    "aliases": [
+      "rose"
+    ],
+    "description": "rose",
+    "tags": [
+      "flower"
+    ],
+    "emoji": "🌹"
+  },
+  {
+    "aliases": [
+      "construction"
+    ],
+    "description": "construction sign",
+    "tags": [
+      "wip"
+    ],
+    "emoji": "🚧"
+  },
+  {
+    "aliases": [
+      "railway_track"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "railway track",
+    "tags": [],
+    "emoji": "🛤"
+  },
+  {
+    "aliases": [
+      "mostly_sunny",
+      "white_sun_small_cloud",
+      "sun_small_cloud"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "white sun with small cloud",
+    "tags": [],
+    "emoji": "🌤"
+  },
+  {
+    "aliases": [
+      "flag-pe",
+      "pe"
+    ],
+    "emoji": "🇵🇪",
+    "description": "regional indicator symbol letter p + regional indicator symbol letter e",
+    "tags": [
+      "flag",
+      "peru"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-ph",
+      "ph"
+    ],
+    "emoji": "🇵🇭",
+    "description": "regional indicator symbol letter p + regional indicator symbol letter h",
+    "tags": [
+      "flag",
+      "philippines"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-li",
+      "li"
+    ],
+    "emoji": "🇱🇮",
+    "description": "regional indicator symbol letter l + regional indicator symbol letter i",
+    "tags": [
+      "flag",
+      "liechtenstein"
+    ]
+  },
+  {
+    "aliases": [
+      "stars"
+    ],
+    "description": "shooting star",
+    "tags": [],
+    "emoji": "🌠"
+  },
+  {
+    "aliases": [
+      "oil_drum"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "oil drum",
+    "tags": [],
+    "emoji": "🛢"
+  },
+  {
+    "aliases": [
+      "taco"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "taco",
+    "tags": [],
+    "emoji": "🌮"
+  },
+  {
+    "aliases": [
+      "wrap",
+      "burrito"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "burrito",
+    "tags": [],
+    "emoji": "🌯"
+  },
+  {
+    "aliases": [
+      "mother_nature",
+      "wind_blowing_face",
+      "blowing_wind"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "wind blowing face",
+    "tags": [],
+    "emoji": "🌬"
+  },
+  {
+    "aliases": [
+      "hot_dog",
+      "hotdog"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "hot dog",
+    "tags": [],
+    "emoji": "🌭"
+  },
+  {
+    "aliases": [
+      "small_airplane"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "small airplane",
+    "tags": [],
+    "emoji": "🛩"
+  },
+  {
+    "aliases": [
+      "fog"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "fog",
+    "tags": [],
+    "emoji": "🌫"
+  },
+  {
+    "aliases": [
+      "airplane_departure",
+      "take_off"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "airplane departure",
+    "tags": [],
+    "emoji": "🛫"
+  },
+  {
+    "aliases": [
+      "flag-pa",
+      "pa"
+    ],
+    "emoji": "🇵🇦",
+    "description": "regional indicator symbol letter p + regional indicator symbol letter a",
+    "tags": [
+      "flag",
+      "panama"
+    ]
+  },
+  {
+    "aliases": [
+      "waning_gibbous_moon"
+    ],
+    "description": "waning gibbous moon symbol",
+    "tags": [],
+    "emoji": "🌖"
+  },
+  {
+    "aliases": [
+      "last_quarter_moon"
+    ],
+    "description": "last quarter moon symbol",
+    "tags": [],
+    "emoji": "🌗"
+  },
+  {
+    "aliases": [
+      "waxing_gibbous_moon",
+      "moon"
+    ],
+    "description": "waxing gibbous moon symbol",
+    "tags": [],
+    "emoji": "🌔"
+  },
+  {
+    "aliases": [
+      "full_moon"
+    ],
+    "description": "full moon symbol",
+    "tags": [],
+    "emoji": "🌕"
+  },
+  {
+    "aliases": [
+      "waxing_crescent_moon"
+    ],
+    "description": "waxing crescent moon symbol",
+    "tags": [],
+    "emoji": "🌒"
+  },
+  {
+    "aliases": [
+      "first_quarter_moon"
+    ],
+    "description": "first quarter moon symbol",
+    "tags": [],
+    "emoji": "🌓"
+  },
+  {
+    "aliases": [
+      "globe_with_meridians"
+    ],
+    "description": "globe with meridians",
+    "tags": [
+      "world",
+      "global",
+      "international"
+    ],
+    "emoji": "🌐"
+  },
+  {
+    "aliases": [
+      "new_moon"
+    ],
+    "description": "new moon symbol",
+    "tags": [],
+    "emoji": "🌑"
+  },
+  {
+    "aliases": [
+      "sun_with_face"
+    ],
+    "description": "sun with face",
+    "tags": [
+      "summer"
+    ],
+    "emoji": "🌞"
+  },
+  {
+    "aliases": [
+      "star2"
+    ],
+    "description": "glowing star",
+    "tags": [],
+    "emoji": "🌟"
+  },
+  {
+    "aliases": [
+      "last_quarter_moon_with_face"
+    ],
+    "description": "last quarter moon with face",
+    "tags": [],
+    "emoji": "🌜"
+  },
+  {
+    "aliases": [
+      "full_moon_with_face"
+    ],
+    "description": "full moon with face",
+    "tags": [],
+    "emoji": "🌝"
+  },
+  {
+    "aliases": [
+      "new_moon_with_face"
+    ],
+    "description": "new moon with face",
+    "tags": [],
+    "emoji": "🌚"
+  },
+  {
+    "aliases": [
+      "first_quarter_moon_with_face"
+    ],
+    "description": "first quarter moon with face",
+    "tags": [],
+    "emoji": "🌛"
+  },
+  {
+    "aliases": [
+      "waning_crescent_moon"
+    ],
+    "description": "waning crescent moon symbol",
+    "tags": [],
+    "emoji": "🌘"
+  },
+  {
+    "aliases": [
+      "crescent_moon"
+    ],
+    "description": "crescent moon",
+    "tags": [
+      "night"
+    ],
+    "emoji": "🌙"
+  },
+  {
+    "aliases": [
+      "city_sunset"
+    ],
+    "description": "cityscape at dusk",
+    "tags": [],
+    "emoji": "🌆"
+  },
+  {
+    "aliases": [
+      "city_sunrise"
+    ],
+    "description": "sunset over buildings",
+    "tags": [],
+    "emoji": "🌇"
+  },
+  {
+    "aliases": [
+      "sunrise_over_mountains"
+    ],
+    "description": "sunrise over mountains",
+    "tags": [],
+    "emoji": "🌄"
+  },
+  {
+    "aliases": [
+      "sunrise"
+    ],
+    "description": "sunrise",
+    "tags": [],
+    "emoji": "🌅"
+  },
+  {
+    "aliases": [
+      "closed_umbrella"
+    ],
+    "description": "closed umbrella",
+    "tags": [
+      "weather",
+      "rain"
+    ],
+    "emoji": "🌂"
+  },
+  {
+    "aliases": [
+      "bath"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "bath",
+    "tags": [
+      "shower"
+    ],
+    "emoji": "🛀"
+  },
+  {
+    "aliases": [
+      "cyclone"
+    ],
+    "description": "cyclone",
+    "tags": [
+      "swirl"
+    ],
+    "emoji": "🌀"
+  },
+  {
+    "aliases": [
+      "foggy"
+    ],
+    "description": "foggy",
+    "tags": [
+      "karl"
+    ],
+    "emoji": "🌁"
+  },
+  {
+    "aliases": [
+      "earth_americas"
+    ],
+    "description": "earth globe americas",
+    "tags": [
+      "globe",
+      "world",
+      "international"
+    ],
+    "emoji": "🌎"
+  },
+  {
+    "aliases": [
+      "earth_asia"
+    ],
+    "description": "earth globe asia-australia",
+    "tags": [
+      "globe",
+      "world",
+      "international"
+    ],
+    "emoji": "🌏"
+  },
+  {
+    "aliases": [
+      "milky_way"
+    ],
+    "description": "milky way",
+    "tags": [],
+    "emoji": "🌌"
+  },
+  {
+    "aliases": [
+      "earth_africa"
+    ],
+    "description": "earth globe europe-africa",
+    "tags": [
+      "globe",
+      "world",
+      "international"
+    ],
+    "emoji": "🌍"
+  },
+  {
+    "aliases": [
+      "ocean"
+    ],
+    "description": "water wave",
+    "tags": [
+      "sea"
+    ],
+    "emoji": "🌊"
+  },
+  {
+    "aliases": [
+      "volcano"
+    ],
+    "description": "volcano",
+    "tags": [],
+    "emoji": "🌋"
+  },
+  {
+    "aliases": [
+      "rainbow"
+    ],
+    "description": "rainbow",
+    "tags": [
+      "pride"
+    ],
+    "emoji": "🌈"
+  },
+  {
+    "aliases": [
+      "black_joker"
+    ],
+    "description": "playing card black joker",
+    "tags": [],
+    "emoji": "🃏"
+  },
+  {
+    "aliases": [
+      "mountain_bicyclist"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "mountain bicyclist",
+    "tags": [],
+    "emoji": "🚵"
+  },
+  {
+    "aliases": [
+      "bicyclist"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "bicyclist",
+    "tags": [],
+    "emoji": "🚴"
+  },
+  {
+    "aliases": [
+      "fork_and_knife"
+    ],
+    "description": "fork and knife",
+    "tags": [
+      "cutlery"
+    ],
+    "emoji": "🍴"
+  },
+  {
+    "aliases": [
+      "walking"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "pedestrian",
+    "tags": [],
+    "emoji": "🚶"
+  },
+  {
+    "aliases": [
+      "stew"
+    ],
+    "description": "pot of food",
+    "tags": [],
+    "emoji": "🍲"
+  },
+  {
+    "aliases": [
+      "egg"
+    ],
+    "description": "cooking",
+    "tags": [
+      "breakfast"
+    ],
+    "emoji": "🍳"
+  },
+  {
+    "aliases": [
+      "cake"
+    ],
+    "description": "shortcake",
+    "tags": [
+      "dessert"
+    ],
+    "emoji": "🍰"
+  },
+  {
+    "aliases": [
+      "bento"
+    ],
+    "description": "bento box",
+    "tags": [],
+    "emoji": "🍱"
+  },
+  {
+    "aliases": [
+      "toilet"
+    ],
+    "description": "toilet",
+    "tags": [
+      "wc"
+    ],
+    "emoji": "🚽"
+  },
+  {
+    "aliases": [
+      "baby_symbol"
+    ],
+    "description": "baby symbol",
+    "tags": [],
+    "emoji": "🚼"
+  },
+  {
+    "aliases": [
+      "shower"
+    ],
+    "description": "shower",
+    "tags": [
+      "bath"
+    ],
+    "emoji": "🚿"
+  },
+  {
+    "aliases": [
+      "wc"
+    ],
+    "description": "water closet",
+    "tags": [
+      "toilet",
+      "restroom"
+    ],
+    "emoji": "🚾"
+  },
+  {
+    "aliases": [
+      "beer"
+    ],
+    "description": "beer mug",
+    "tags": [
+      "drink"
+    ],
+    "emoji": "🍺"
+  },
+  {
+    "aliases": [
+      "beers"
+    ],
+    "description": "clinking beer mugs",
+    "tags": [
+      "drinks"
+    ],
+    "emoji": "🍻"
+  },
+  {
+    "aliases": [
+      "cocktail"
+    ],
+    "description": "cocktail glass",
+    "tags": [
+      "drink"
+    ],
+    "emoji": "🍸"
+  },
+  {
+    "aliases": [
+      "tropical_drink"
+    ],
+    "description": "tropical drink",
+    "tags": [
+      "summer",
+      "vacation"
+    ],
+    "emoji": "🍹"
+  },
+  {
+    "aliases": [
+      "icecream"
+    ],
+    "description": "soft ice cream",
+    "tags": [],
+    "emoji": "🍦"
+  },
+  {
+    "aliases": [
+      "shaved_ice"
+    ],
+    "description": "shaved ice",
+    "tags": [],
+    "emoji": "🍧"
+  },
+  {
+    "aliases": [
+      "fried_shrimp"
+    ],
+    "description": "fried shrimp",
+    "tags": [
+      "tempura"
+    ],
+    "emoji": "🍤"
+  },
+  {
+    "aliases": [
+      "fish_cake"
+    ],
+    "description": "fish cake with swirl design",
+    "tags": [],
+    "emoji": "🍥"
+  },
+  {
+    "aliases": [
+      "oden"
+    ],
+    "description": "oden",
+    "tags": [],
+    "emoji": "🍢"
+  },
+  {
+    "aliases": [
+      "sushi"
+    ],
+    "description": "sushi",
+    "tags": [],
+    "emoji": "🍣"
+  },
+  {
+    "aliases": [
+      "sweet_potato"
+    ],
+    "description": "roasted sweet potato",
+    "tags": [],
+    "emoji": "🍠"
+  },
+  {
+    "aliases": [
+      "dango"
+    ],
+    "description": "dango",
+    "tags": [],
+    "emoji": "🍡"
+  },
+  {
+    "aliases": [
+      "custard"
+    ],
+    "description": "custard",
+    "tags": [],
+    "emoji": "🍮"
+  },
+  {
+    "aliases": [
+      "smoking"
+    ],
+    "description": "smoking symbol",
+    "tags": [
+      "cigarette"
+    ],
+    "emoji": "🚬"
+  },
+  {
+    "aliases": [
+      "candy"
+    ],
+    "description": "candy",
+    "tags": [
+      "sweet"
+    ],
+    "emoji": "🍬"
+  },
+  {
+    "aliases": [
+      "lollipop"
+    ],
+    "description": "lollipop",
+    "tags": [],
+    "emoji": "🍭"
+  },
+  {
+    "aliases": [
+      "cookie"
+    ],
+    "description": "cookie",
+    "tags": [],
+    "emoji": "🍪"
+  },
+  {
+    "aliases": [
+      "chocolate_bar"
+    ],
+    "description": "chocolate bar",
+    "tags": [],
+    "emoji": "🍫"
+  },
+  {
+    "aliases": [
+      "ice_cream"
+    ],
+    "description": "ice cream",
+    "tags": [],
+    "emoji": "🍨"
+  },
+  {
+    "aliases": [
+      "door"
+    ],
+    "description": "door",
+    "tags": [],
+    "emoji": "🚪"
+  },
+  {
+    "aliases": [
+      "meat_on_bone"
+    ],
+    "description": "meat on bone",
+    "tags": [],
+    "emoji": "🍖"
+  },
+  {
+    "aliases": [
+      "poultry_leg"
+    ],
+    "description": "poultry leg",
+    "tags": [
+      "meat",
+      "chicken"
+    ],
+    "emoji": "🍗"
+  },
+  {
+    "aliases": [
+      "hamburger"
+    ],
+    "description": "hamburger",
+    "tags": [
+      "burger"
+    ],
+    "emoji": "🍔"
+  },
+  {
+    "aliases": [
+      "pizza"
+    ],
+    "description": "slice of pizza",
+    "tags": [],
+    "emoji": "🍕"
+  },
+  {
+    "aliases": [
+      "cherries"
+    ],
+    "description": "cherries",
+    "tags": [
+      "fruit"
+    ],
+    "emoji": "🍒"
+  },
+  {
+    "aliases": [
+      "strawberry"
+    ],
+    "description": "strawberry",
+    "tags": [
+      "fruit"
+    ],
+    "emoji": "🍓"
+  },
+  {
+    "aliases": [
+      "pear"
+    ],
+    "description": "pear",
+    "tags": [],
+    "emoji": "🍐"
+  },
+  {
+    "aliases": [
+      "peach"
+    ],
+    "description": "peach",
+    "tags": [],
+    "emoji": "🍑"
+  },
+  {
+    "aliases": [
+      "bread"
+    ],
+    "description": "bread",
+    "tags": [
+      "toast"
+    ],
+    "emoji": "🍞"
+  },
+  {
+    "aliases": [
+      "fries"
+    ],
+    "description": "french fries",
+    "tags": [],
+    "emoji": "🍟"
+  },
+  {
+    "aliases": [
+      "ramen"
+    ],
+    "description": "steaming bowl",
+    "tags": [
+      "noodle"
+    ],
+    "emoji": "🍜"
+  },
+  {
+    "aliases": [
+      "spaghetti"
+    ],
+    "description": "spaghetti",
+    "tags": [
+      "pasta"
+    ],
+    "emoji": "🍝"
+  },
+  {
+    "aliases": [
+      "rice"
+    ],
+    "description": "cooked rice",
+    "tags": [],
+    "emoji": "🍚"
+  },
+  {
+    "aliases": [
+      "curry"
+    ],
+    "description": "curry and rice",
+    "tags": [],
+    "emoji": "🍛"
+  },
+  {
+    "aliases": [
+      "rice_cracker"
+    ],
+    "description": "rice cracker",
+    "tags": [],
+    "emoji": "🍘"
+  },
+  {
+    "aliases": [
+      "rice_ball"
+    ],
+    "description": "rice ball",
+    "tags": [],
+    "emoji": "🍙"
+  },
+  {
+    "aliases": [
+      "eggplant"
+    ],
+    "description": "aubergine",
+    "tags": [
+      "aubergine"
+    ],
+    "emoji": "🍆"
+  },
+  {
+    "aliases": [
+      "grapes"
+    ],
+    "description": "grapes",
+    "tags": [],
+    "emoji": "🍇"
+  },
+  {
+    "aliases": [
+      "mushroom"
+    ],
+    "description": "mushroom",
+    "tags": [],
+    "emoji": "🍄"
+  },
+  {
+    "aliases": [
+      "tomato"
+    ],
+    "description": "tomato",
+    "tags": [],
+    "emoji": "🍅"
+  },
+  {
+    "aliases": [
+      "fallen_leaf"
+    ],
+    "description": "fallen leaf",
+    "tags": [
+      "autumn"
+    ],
+    "emoji": "🍂"
+  },
+  {
+    "aliases": [
+      "leaves"
+    ],
+    "description": "leaf fluttering in wind",
+    "tags": [
+      "leaf"
+    ],
+    "emoji": "🍃"
+  },
+  {
+    "aliases": [
+      "four_leaf_clover"
+    ],
+    "description": "four leaf clover",
+    "tags": [
+      "luck"
+    ],
+    "emoji": "🍀"
+  },
+  {
+    "aliases": [
+      "maple_leaf"
+    ],
+    "description": "maple leaf",
+    "tags": [
+      "canada"
+    ],
+    "emoji": "🍁"
+  },
+  {
+    "aliases": [
+      "apple"
+    ],
+    "description": "red apple",
+    "tags": [],
+    "emoji": "🍎"
+  },
+  {
+    "aliases": [
+      "green_apple"
+    ],
+    "description": "green apple",
+    "tags": [
+      "fruit"
+    ],
+    "emoji": "🍏"
+  },
+  {
+    "aliases": [
+      "banana"
+    ],
+    "description": "banana",
+    "tags": [
+      "fruit"
+    ],
+    "emoji": "🍌"
+  },
+  {
+    "aliases": [
+      "crocodile"
+    ],
+    "description": "crocodile",
+    "tags": [],
+    "emoji": "🐊"
+  },
+  {
+    "aliases": [
+      "tangerine"
+    ],
+    "description": "tangerine",
+    "tags": [],
+    "emoji": "🍊"
+  },
+  {
+    "aliases": [
+      "lemon"
+    ],
+    "description": "lemon",
+    "tags": [],
+    "emoji": "🍋"
+  },
+  {
+    "aliases": [
+      "melon"
+    ],
+    "description": "melon",
+    "tags": [],
+    "emoji": "🍈"
+  },
+  {
+    "aliases": [
+      "watermelon"
+    ],
+    "description": "watermelon",
+    "tags": [],
+    "emoji": "🍉"
+  },
+  {
+    "aliases": [
+      "jo",
+      "flag-jo"
+    ],
+    "emoji": "🇯🇴",
+    "description": "regional indicator symbol letter j + regional indicator symbol letter o",
+    "tags": [
+      "flag",
+      "jordan"
+    ]
+  },
+  {
+    "aliases": [
+      "seven"
+    ],
+    "description": "digit seven + combining enclosing keycap",
+    "tags": [],
+    "emoji": "7⃣"
+  },
+  {
+    "aliases": [
+      "hr",
+      "flag-hr"
+    ],
+    "emoji": "🇭🇷",
+    "description": "regional indicator symbol letter h + regional indicator symbol letter r",
+    "tags": [
+      "flag",
+      "croatia"
+    ]
+  },
+  {
+    "aliases": [
+      "mobile_phone_off"
+    ],
+    "description": "mobile phone off",
+    "tags": [
+      "mute",
+      "off"
+    ],
+    "emoji": "📴"
+  },
+  {
+    "aliases": [
+      "fj",
+      "flag-fj"
+    ],
+    "emoji": "🇫🇯",
+    "description": "regional indicator symbol letter f + regional indicator symbol letter j",
+    "tags": [
+      "flag",
+      "fiji"
+    ]
+  },
+  {
+    "aliases": [
+      "airplane"
+    ],
+    "description": "airplane",
+    "tags": [
+      "flight"
+    ],
+    "emoji": "✈"
+  },
+  {
+    "aliases": [
+      "phone",
+      "telephone"
+    ],
+    "description": "black telephone",
+    "tags": [],
+    "emoji": "☎"
+  },
+  {
+    "aliases": [
+      "fr",
+      "flag-fr"
+    ],
+    "emoji": "🇫🇷",
+    "description": "regional indicator symbol letter f + regional indicator symbol letter r",
+    "tags": [
+      "flag",
+      "france"
+    ]
+  },
+  {
+    "aliases": [
+      "woman-woman-girl-girl",
+      "family_woman_woman_girl_girl"
+    ],
+    "description": "family (woman, woman, girl, girl)",
+    "tags": [
+      "family",
+      "woman",
+      "girl"
+    ],
+    "emoji": "👩‍👩‍👧‍👧"
+  },
+  {
+    "aliases": [
+      "flag-fo",
+      "fo"
+    ],
+    "emoji": "🇫🇴",
+    "description": "regional indicator symbol letter f + regional indicator symbol letter o",
+    "tags": [
+      "flag",
+      "faroe islands"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-fm"
+    ],
+    "description": "regional indicator symbol letters fm",
+    "tags": [],
+    "emoji": "🇫🇲"
+  },
+  {
+    "aliases": [
+      "vertical_traffic_light"
+    ],
+    "description": "vertical traffic light",
+    "tags": [
+      "semaphore"
+    ],
+    "emoji": "🚦"
+  },
+  {
+    "aliases": [
+      "flag-fk"
+    ],
+    "description": "regional indicator symbol letters fk",
+    "tags": [],
+    "emoji": "🇫🇰"
+  },
+  {
+    "aliases": [
+      "gear"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "gear",
+    "tags": [],
+    "emoji": "⚙"
+  },
+  {
+    "aliases": [
+      "cl"
+    ],
+    "description": "squared cl",
+    "tags": [],
+    "emoji": "🆑"
+  },
+  {
+    "aliases": [
+      "peace_symbol",
+      "peace_sign"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "peace symbol",
+    "tags": [],
+    "emoji": "☮"
+  },
+  {
+    "aliases": [
+      "woman-kiss-woman"
+    ],
+    "description": "",
+    "tags": [],
+    "emoji": "👩‍❤️‍💋‍👩"
+  },
+  {
+    "aliases": [
+      "keycap_asterisk",
+      "keycap_star",
+      "star_keycap"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "keycap asterisk",
+    "tags": [],
+    "emoji": "*⃣"
+  },
+  {
+    "aliases": [
+      "sleeping_accommodation"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "sleeping accommodation",
+    "tags": [],
+    "emoji": "🛌"
+  },
+  {
+    "aliases": [
+      "funeral_urn"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "funeral urn",
+    "tags": [],
+    "emoji": "⚱"
+  },
+  {
+    "aliases": [
+      "flag-hu",
+      "hu"
+    ],
+    "emoji": "🇭🇺",
+    "description": "regional indicator symbol letter h + regional indicator symbol letter u",
+    "tags": [
+      "flag",
+      "hungary"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-la",
+      "la"
+    ],
+    "emoji": "🇱🇦",
+    "description": "regional indicator symbol letter l + regional indicator symbol letter a",
+    "tags": [
+      "flag",
+      "laos"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-mz",
+      "mz"
+    ],
+    "emoji": "🇲🇿",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter z",
+    "tags": [
+      "flag",
+      "mozambique"
+    ]
+  },
+  {
+    "aliases": [
+      "sparkles"
+    ],
+    "description": "sparkles",
+    "tags": [
+      "shiny"
+    ],
+    "emoji": "✨"
+  },
+  {
     "aliases": [
       "printer"
     ],
-    "tags": []
+    "supports_fitzpatrick": false,
+    "description": "printer",
+    "tags": [],
+    "emoji": "🖨"
   },
   {
-    "emoji": "⌨",
-    "description": "keyboard",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "keyboard"
+      "skin-tone-6"
     ],
-    "tags": []
+    "description": "emoji modifier fitzpatrick type-6",
+    "tags": [],
+    "emoji": "🏿"
   },
   {
-    "emoji": "🖱",
-    "description": "three button mouse",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "computer_mouse",
-      "three_button_mouse"
+      "aerial_tramway"
     ],
-    "tags": []
+    "description": "aerial tramway",
+    "tags": [],
+    "emoji": "🚡"
   },
   {
-    "emoji": "🖲",
-    "description": "trackball",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "trackball"
+      "flag-kw",
+      "kw"
     ],
-    "tags": []
+    "emoji": "🇰🇼",
+    "description": "regional indicator symbol letter k + regional indicator symbol letter w",
+    "tags": [
+      "flag",
+      "kuwait"
+    ]
   },
   {
-    "emoji": "📽",
-    "description": "film projector",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "film_projector"
+      "motor_boat"
     ],
-    "tags": []
+    "supports_fitzpatrick": false,
+    "description": "motor boat",
+    "tags": [],
+    "emoji": "🛥"
   },
   {
-    "emoji": "📸",
-    "description": "camera with flash",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "camera_flash"
+      "flag-mv",
+      "mv"
     ],
-    "tags": []
+    "emoji": "🇲🇻",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter v",
+    "tags": [
+      "flag",
+      "maldives"
+    ]
   },
   {
-    "emoji": "🕯",
-    "description": "candle burning",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "candle"
+      "tc",
+      "flag-tc"
     ],
-    "tags": []
+    "emoji": "🇹🇨",
+    "description": "regional indicator symbol letter t + regional indicator symbol letter c",
+    "tags": [
+      "flag",
+      "turks and caicos islands"
+    ]
   },
   {
-    "emoji": "🗞",
-    "description": "newspaper rolled up for delivery",
+    "aliases": [
+      "flag-bv"
+    ],
+    "description": "regional indicator symbol letters bv",
+    "tags": [],
+    "emoji": "🇧🇻"
+  },
+  {
+    "aliases": [
+      "cheese",
+      "cheese_wedge"
+    ],
     "supports_fitzpatrick": false,
+    "description": "cheese wedge",
+    "tags": [],
+    "emoji": "🧀"
+  },
+  {
+    "aliases": [
+      "libra"
+    ],
+    "description": "libra",
+    "tags": [],
+    "emoji": "♎"
+  },
+  {
+    "aliases": [
+      "star"
+    ],
+    "description": "white medium star",
+    "tags": [],
+    "emoji": "⭐"
+  },
+  {
+    "aliases": [
+      "mountain_cableway"
+    ],
+    "description": "mountain cableway",
+    "tags": [],
+    "emoji": "🚠"
+  },
+  {
+    "aliases": [
+      "spock-hand",
+      "vulcan_salute"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "raised hand with part between middle and ring fingers",
+    "tags": [
+      "vulcan",
+      "salute"
+    ],
+    "emoji": "🖖"
+  },
+  {
+    "aliases": [
+      "pick"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "pick",
+    "tags": [],
+    "emoji": "⛏"
+  },
+  {
+    "aliases": [
+      "flag-bb",
+      "bb"
+    ],
+    "emoji": "🇧🇧",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter b",
+    "tags": [
+      "flag",
+      "barbados"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-mr",
+      "mr"
+    ],
+    "emoji": "🇲🇷",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter r",
+    "tags": [
+      "flag",
+      "mauritania"
+    ]
+  },
+  {
+    "aliases": [
+      "rolling_eyes",
+      "face_with_rolling_eyes",
+      "eye_roll"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "face with rolling eyes",
+    "tags": [],
+    "emoji": "🙄"
+  },
+  {
+    "aliases": [
+      "flag-mo",
+      "mo"
+    ],
+    "emoji": "🇲🇴",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter o",
+    "tags": [
+      "flag",
+      "macau"
+    ]
+  },
+  {
+    "aliases": [
+      "skin-tone-4"
+    ],
+    "description": "emoji modifier fitzpatrick type-4",
+    "tags": [],
+    "emoji": "🏽"
+  },
+  {
+    "aliases": [
+      "man-heart-man"
+    ],
+    "description": "",
+    "tags": [],
+    "emoji": "👨‍❤️‍👨"
+  },
+  {
+    "aliases": [
+      "lb",
+      "flag-lb"
+    ],
+    "emoji": "🇱🇧",
+    "description": "regional indicator symbol letter l + regional indicator symbol letter b",
+    "tags": [
+      "flag",
+      "lebanon"
+    ]
+  },
+  {
+    "aliases": [
+      "kami_no_michi",
+      "shinto_shrine"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "shinto shrine",
+    "tags": [],
+    "emoji": "⛩"
+  },
+  {
+    "aliases": [
+      "arrow_double_up"
+    ],
+    "description": "black up-pointing double triangle",
+    "tags": [],
+    "emoji": "⏫"
+  },
+  {
+    "aliases": [
+      "tr",
+      "flag-tr"
+    ],
+    "emoji": "🇹🇷",
+    "description": "regional indicator symbol letter t + regional indicator symbol letter r",
+    "tags": [
+      "flag",
+      "turkey"
+    ]
+  },
+  {
+    "aliases": [
+      "chains"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "chains",
+    "tags": [],
+    "emoji": "⛓"
+  },
+  {
+    "aliases": [
+      "light_beam",
+      "comet",
+      "blue_beam"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "comet",
+    "tags": [],
+    "emoji": "☄"
+  },
+  {
+    "aliases": [
+      "hot_pepper",
+      "spicy",
+      "chili_pepper",
+      "spice"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "hot pepper",
+    "tags": [],
+    "emoji": "🌶"
+  },
+  {
+    "aliases": [
+      "person_with_ball"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "person with ball",
+    "tags": [],
+    "emoji": "⛹"
+  },
+  {
+    "aliases": [
+      "white_sun_behind_cloud_rain",
+      "sun_behind_rain_cloud",
+      "partly_sunny_rain"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "white sun behind cloud with rain",
+    "tags": [],
+    "emoji": "🌦"
+  },
+  {
+    "aliases": [
+      "ml",
+      "flag-ml"
+    ],
+    "emoji": "🇲🇱",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter l",
+    "tags": [
+      "flag",
+      "mali"
+    ]
+  },
+  {
+    "aliases": [
+      "regional_indicator_symbol_j"
+    ],
+    "emoji": "🇯",
+    "description": "regional indicator symbol letter j",
+    "tags": [
+      "letter",
+      "j"
+    ]
+  },
+  {
+    "aliases": [
+      "u6709"
+    ],
+    "description": "squared cjk unified ideograph-6709",
+    "tags": [],
+    "emoji": "🈶"
+  },
+  {
+    "aliases": [
+      "u6708"
+    ],
+    "description": "squared cjk unified ideograph-6708",
+    "tags": [],
+    "emoji": "🈷"
+  },
+  {
+    "aliases": [
+      "u5408"
+    ],
+    "description": "squared cjk unified ideograph-5408",
+    "tags": [],
+    "emoji": "🈴"
+  },
+  {
+    "aliases": [
+      "u6e80"
+    ],
+    "description": "squared cjk unified ideograph-6e80",
+    "tags": [],
+    "emoji": "🈵"
+  },
+  {
+    "aliases": [
+      "u7981"
+    ],
+    "description": "squared cjk unified ideograph-7981",
+    "tags": [],
+    "emoji": "🈲"
+  },
+  {
+    "aliases": [
+      "u7a7a"
+    ],
+    "description": "squared cjk unified ideograph-7a7a",
+    "tags": [],
+    "emoji": "🈳"
+  },
+  {
+    "aliases": [
+      "arrow_upper_left"
+    ],
+    "description": "north west arrow",
+    "tags": [],
+    "emoji": "↖"
+  },
+  {
+    "aliases": [
+      "u55b6"
+    ],
+    "description": "squared cjk unified ideograph-55b6",
+    "tags": [],
+    "emoji": "🈺"
+  },
+  {
+    "aliases": [
+      "u7533"
+    ],
+    "description": "squared cjk unified ideograph-7533",
+    "tags": [],
+    "emoji": "🈸"
+  },
+  {
+    "aliases": [
+      "u5272"
+    ],
+    "description": "squared cjk unified ideograph-5272",
+    "tags": [],
+    "emoji": "🈹"
+  },
+  {
+    "aliases": [
+      "mecca",
+      "kaaba"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "kaaba",
+    "tags": [],
+    "emoji": "🕋"
+  },
+  {
+    "aliases": [
+      "cloud_rain",
+      "rain_cloud"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "cloud with rain",
+    "tags": [],
+    "emoji": "🌧"
+  },
+  {
+    "aliases": [
+      "u6307"
+    ],
+    "description": "squared cjk unified ideograph-6307",
+    "tags": [],
+    "emoji": "🈯"
+  },
+  {
+    "aliases": [
+      "hourglass"
+    ],
+    "description": "hourglass",
+    "tags": [
+      "time"
+    ],
+    "emoji": "⌛"
+  },
+  {
+    "aliases": [
+      "flag-de",
+      "de"
+    ],
+    "emoji": "🇩🇪",
+    "description": "regional indicator symbol letter d + regional indicator symbol letter e",
+    "tags": [
+      "flag",
+      "germany"
+    ]
+  },
+  {
+    "aliases": [
+      "ru",
+      "flag-ru"
+    ],
+    "emoji": "🇷🇺",
+    "description": "regional indicator symbol letter r + regional indicator symbol letter u",
+    "tags": [
+      "flag",
+      "russia"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-rs",
+      "rs"
+    ],
+    "emoji": "🇷🇸",
+    "description": "regional indicator symbol letter r + regional indicator symbol letter s",
+    "tags": [
+      "flag",
+      "serbia"
+    ]
+  },
+  {
+    "aliases": [
+      "rw",
+      "flag-rw"
+    ],
+    "emoji": "🇷🇼",
+    "description": "regional indicator symbol letter r + regional indicator symbol letter w",
+    "tags": [
+      "flag",
+      "rwanda"
+    ]
+  },
+  {
+    "aliases": [
+      "pk",
+      "flag-pk"
+    ],
+    "emoji": "🇵🇰",
+    "description": "regional indicator symbol letter p + regional indicator symbol letter k",
+    "tags": [
+      "flag",
+      "pakistan"
+    ]
+  },
+  {
+    "aliases": [
+      "u7121"
+    ],
+    "description": "squared cjk unified ideograph-7121",
+    "tags": [],
+    "emoji": "🈚"
+  },
+  {
+    "aliases": [
+      "ro",
+      "flag-ro"
+    ],
+    "emoji": "🇷🇴",
+    "description": "regional indicator symbol letter r + regional indicator symbol letter o",
+    "tags": [
+      "flag",
+      "romania"
+    ]
+  },
+  {
+    "aliases": [
+      "re",
+      "flag-re"
+    ],
+    "emoji": "🇷🇪",
+    "description": "regional indicator symbol letter r + regional indicator symbol letter e",
+    "tags": [
+      "flag",
+      "reunion"
+    ]
+  },
+  {
+    "aliases": [
+      "one"
+    ],
+    "description": "digit one + combining enclosing keycap",
+    "tags": [],
+    "emoji": "1⃣"
+  },
+  {
+    "aliases": [
+      "fountain"
+    ],
+    "description": "fountain",
+    "tags": [],
+    "emoji": "⛲"
+  },
+  {
+    "aliases": [
+      "sa"
+    ],
+    "description": "squared katakana sa",
+    "tags": [],
+    "emoji": "🈂"
+  },
+  {
+    "aliases": [
+      "closed_lock_with_key"
+    ],
+    "description": "closed lock with key",
+    "tags": [
+      "security"
+    ],
+    "emoji": "🔐"
+  },
+  {
+    "aliases": [
+      "koko"
+    ],
+    "description": "squared katakana koko",
+    "tags": [],
+    "emoji": "🈁"
+  },
+  {
+    "aliases": [
+      "frowning_face",
+      "white_frowning_face"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "white frowning face",
+    "tags": [],
+    "emoji": "☹"
+  },
+  {
+    "aliases": [
+      "flag-xk"
+    ],
+    "description": "regional indicator symbol letters xk",
+    "tags": [],
+    "emoji": "🇽🇰"
+  },
+  {
+    "aliases": [
+      "part_alternation_mark"
+    ],
+    "description": "part alternation mark",
+    "tags": [],
+    "emoji": "〽"
+  },
+  {
+    "aliases": [
+      "flag-vn",
+      "vn"
+    ],
+    "emoji": "🇻🇳",
+    "description": "regional indicator symbol letter v + regional indicator symbol letter n",
+    "tags": [
+      "flag",
+      "vietnam"
+    ]
+  },
+  {
+    "aliases": [
+      "baseball"
+    ],
+    "description": "baseball",
+    "tags": [
+      "sports"
+    ],
+    "emoji": "⚾"
+  },
+  {
+    "aliases": [
+      "nz",
+      "flag-nz"
+    ],
+    "emoji": "🇳🇿",
+    "description": "regional indicator symbol letter n + regional indicator symbol letter z",
+    "tags": [
+      "flag",
+      "new zealand"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-hm"
+    ],
+    "description": "regional indicator symbol letters hm",
+    "tags": [],
+    "emoji": "🇭🇲"
+  },
+  {
+    "aliases": [
+      "flag-nu",
+      "nu"
+    ],
+    "emoji": "🇳🇺",
+    "description": "regional indicator symbol letter n + regional indicator symbol letter u",
+    "tags": [
+      "flag",
+      "niue"
+    ]
+  },
+  {
+    "aliases": [
+      "taurus"
+    ],
+    "description": "taurus",
+    "tags": [],
+    "emoji": "♉"
+  },
+  {
+    "aliases": [
+      "black_square_for_stop"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "black square for stop",
+    "tags": [],
+    "emoji": "⏹"
+  },
+  {
+    "aliases": [
+      "np",
+      "flag-np"
+    ],
+    "emoji": "🇳🇵",
+    "description": "regional indicator symbol letter n + regional indicator symbol letter p",
+    "tags": [
+      "flag",
+      "nepal"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-no",
+      "no"
+    ],
+    "emoji": "🇳🇴",
+    "description": "regional indicator symbol letter n + regional indicator symbol letter o",
+    "tags": [
+      "flag",
+      "norway"
+    ]
+  },
+  {
+    "aliases": [
+      "card_index_dividers"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "card index dividers",
+    "tags": [],
+    "emoji": "🗂"
+  },
+  {
+    "aliases": [
+      "flag-nl",
+      "nl"
+    ],
+    "emoji": "🇳🇱",
+    "description": "regional indicator symbol letter n + regional indicator symbol letter l",
+    "tags": [
+      "flag",
+      "netherlands"
+    ]
+  },
+  {
+    "aliases": [
+      "ophiuchus"
+    ],
+    "description": "ophiuchus",
+    "tags": [],
+    "emoji": "⛎"
+  },
+  {
+    "aliases": [
+      "jm",
+      "flag-jm"
+    ],
+    "emoji": "🇯🇲",
+    "description": "regional indicator symbol letter j + regional indicator symbol letter m",
+    "tags": [
+      "flag",
+      "jamaica"
+    ]
+  },
+  {
+    "aliases": [
+      "ni",
+      "flag-ni"
+    ],
+    "emoji": "🇳🇮",
+    "description": "regional indicator symbol letter n + regional indicator symbol letter i",
+    "tags": [
+      "flag",
+      "nicaragua"
+    ]
+  },
+  {
+    "aliases": [
+      "question"
+    ],
+    "description": "black question mark ornament",
+    "tags": [
+      "confused"
+    ],
+    "emoji": "❓"
+  },
+  {
+    "aliases": [
+      "flag-ng",
+      "ng"
+    ],
+    "emoji": "🇳🇬",
+    "description": "regional indicator symbol letter n + regional indicator symbol letter g",
+    "tags": [
+      "flag",
+      "nigeria"
+    ]
+  },
+  {
+    "aliases": [
+      "sun_behind_cloud",
+      "white_sun_behind_cloud",
+      "barely_sunny"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "white sun behind cloud",
+    "tags": [],
+    "emoji": "🌥"
+  },
+  {
+    "aliases": [
+      "flag-ne",
+      "ne"
+    ],
+    "emoji": "🇳🇪",
+    "description": "regional indicator symbol letter n + regional indicator symbol letter e",
+    "tags": [
+      "flag",
+      "niger"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-mf"
+    ],
+    "description": "regional indicator symbol letters mf",
+    "tags": [],
+    "emoji": "🇲🇫"
+  },
+  {
+    "aliases": [
+      "nc",
+      "flag-nc"
+    ],
+    "emoji": "🇳🇨",
+    "description": "regional indicator symbol letter n + regional indicator symbol letter c",
+    "tags": [
+      "flag",
+      "new caledonia"
+    ]
+  },
+  {
+    "aliases": [
+      "na",
+      "flag-na"
+    ],
+    "emoji": "🇳🇦",
+    "description": "regional indicator symbol letter n + regional indicator symbol letter a",
+    "tags": [
+      "flag",
+      "namibia"
+    ]
+  },
+  {
+    "aliases": [
+      "tf",
+      "flag-tf"
+    ],
+    "emoji": "🇹🇫",
+    "description": "regional indicator symbol letter t + regional indicator symbol letter f",
+    "tags": [
+      "flag",
+      "french southern territories"
+    ]
+  },
+  {
+    "aliases": [
+      "zm",
+      "flag-zm"
+    ],
+    "emoji": "🇿🇲",
+    "description": "regional indicator symbol letter z + regional indicator symbol letter m",
+    "tags": [
+      "flag",
+      "zambia"
+    ]
+  },
+  {
+    "aliases": [
+      "heavy_heart_exclamation_mark_ornament",
+      "exclamation_heart"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "heavy heart exclamation mark ornament",
+    "tags": [],
+    "emoji": "❣"
+  },
+  {
+    "aliases": [
+      "ideograph_advantage"
+    ],
+    "description": "circled ideograph advantage",
+    "tags": [],
+    "emoji": "🉐"
+  },
+  {
+    "aliases": [
+      "accept"
+    ],
+    "description": "circled ideograph accept",
+    "tags": [],
+    "emoji": "🉑"
+  },
+  {
+    "aliases": [
+      "flag-sx"
+    ],
+    "description": "regional indicator symbol letters sx",
+    "tags": [],
+    "emoji": "🇸🇽"
+  },
+  {
+    "aliases": [
+      "timid_lion",
+      "lion_face",
+      "cute_lion"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "lion face",
+    "tags": [],
+    "emoji": "🦁"
+  },
+  {
+    "aliases": [
+      "thunder_cloud_and_rain",
+      "thunder_cloud_rain"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "thunder cloud and rain",
+    "tags": [],
+    "emoji": "⛈"
+  },
+  {
+    "aliases": [
+      "sos"
+    ],
+    "description": "squared sos",
+    "tags": [
+      "help",
+      "emergency"
+    ],
+    "emoji": "🆘"
+  },
+  {
+    "aliases": [
+      "flag-td"
+    ],
+    "description": "regional indicator symbol letters td",
+    "tags": [],
+    "emoji": "🇹🇩"
+  },
+  {
+    "aliases": [
+      "zw",
+      "flag-zw"
+    ],
+    "emoji": "🇿🇼",
+    "description": "regional indicator symbol letter z + regional indicator symbol letter w",
+    "tags": [
+      "flag",
+      "zimbabwe"
+    ]
+  },
+  {
+    "aliases": [
+      "bangbang"
+    ],
+    "description": "double exclamation mark",
+    "tags": [],
+    "emoji": "‼"
+  },
+  {
+    "aliases": [
+      "alarm_clock"
+    ],
+    "description": "alarm clock",
+    "tags": [
+      "morning"
+    ],
+    "emoji": "⏰"
+  },
+  {
+    "aliases": [
+      "studio_microphone"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "studio microphone",
+    "tags": [],
+    "emoji": "🎙"
+  },
+  {
+    "aliases": [
+      "flag-za",
+      "za"
+    ],
+    "emoji": "🇿🇦",
+    "description": "regional indicator symbol letter z + regional indicator symbol letter a",
+    "tags": [
+      "flag",
+      "south africa"
+    ]
+  },
+  {
+    "aliases": [
+      "om",
+      "flag-om"
+    ],
+    "emoji": "🇴🇲",
+    "description": "regional indicator symbol letter o + regional indicator symbol letter m",
+    "tags": [
+      "flag",
+      "oman"
+    ]
+  },
+  {
+    "aliases": [
+      "scissors"
+    ],
+    "description": "black scissors",
+    "tags": [
+      "cut"
+    ],
+    "emoji": "✂"
+  },
+  {
+    "aliases": [
+      "ballot_box_with_ballot",
+      "ballot",
+      "ballot_box"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "ballot bow with ballot",
+    "tags": [],
+    "emoji": "🗳"
+  },
+  {
+    "aliases": [
+      "hammer_and_wrench"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "hammer and wrench",
+    "tags": [],
+    "emoji": "🛠"
+  },
+  {
+    "aliases": [
+      "flag-pl",
+      "pl"
+    ],
+    "emoji": "🇵🇱",
+    "description": "regional indicator symbol letter p + regional indicator symbol letter l",
+    "tags": [
+      "flag",
+      "polnad"
+    ]
+  },
+  {
+    "aliases": [
+      "black_nib"
+    ],
+    "description": "black nib",
+    "tags": [],
+    "emoji": "✒"
+  },
+  {
+    "aliases": [
+      "bo",
+      "flag-bo"
+    ],
+    "emoji": "🇧🇴",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter o",
+    "tags": [
+      "flag",
+      "bolivia"
+    ]
+  },
+  {
+    "aliases": [
+      "yin_yang"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "yin yang",
+    "tags": [],
+    "emoji": "☯"
+  },
+  {
+    "aliases": [
+      "alembic"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "alembic",
+    "tags": [],
+    "emoji": "⚗"
+  },
+  {
+    "aliases": [
+      "arrow_lower_left"
+    ],
+    "description": "south west arrow",
+    "tags": [],
+    "emoji": "↙"
+  },
+  {
+    "aliases": [
+      "regional_indicator_symbol_g"
+    ],
+    "emoji": "🇬",
+    "description": "regional indicator symbol letter g",
+    "tags": [
+      "letter",
+      "g"
+    ]
+  },
+  {
+    "aliases": [
+      "watch"
+    ],
+    "description": "watch",
+    "tags": [
+      "time"
+    ],
+    "emoji": "⌚"
+  },
+  {
+    "aliases": [
+      "mosque",
+      "minaret",
+      "domed_roof"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "mosque with domed roof and minaret",
+    "tags": [],
+    "emoji": "🕌"
+  },
+  {
+    "aliases": [
+      "kp",
+      "flag-kp"
+    ],
+    "emoji": "🇰🇵",
+    "description": "regional indicator symbol letter k + regional indicator symbol letter p",
+    "tags": [
+      "flag",
+      "north korea"
+    ]
+  },
+  {
+    "aliases": [
+      "kr",
+      "flag-kr"
+    ],
+    "emoji": "🇰🇷",
+    "description": "regional indicator symbol letter k + regional indicator symbol letter r",
+    "tags": [
+      "flag",
+      "south korea"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-km",
+      "km"
+    ],
+    "emoji": "🇰🇲",
+    "description": "regional indicator symbol letter k + regional indicator symbol letter m",
+    "tags": [
+      "flag",
+      "comoros"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-kn"
+    ],
+    "description": "regional indicator symbol letters kn",
+    "tags": [],
+    "emoji": "🇰🇳"
+  },
+  {
+    "aliases": [
+      "leftwards_arrow_with_hook"
+    ],
+    "description": "leftwards arrow with hook",
+    "tags": [
+      "return"
+    ],
+    "emoji": "↩"
+  },
+  {
+    "aliases": [
+      "ky",
+      "flag-ky"
+    ],
+    "emoji": "🇰🇾",
+    "description": "regional indicator symbol letter k + regional indicator symbol letter y",
+    "tags": [
+      "flag",
+      "cayman islands"
+    ]
+  },
+  {
+    "aliases": [
+      "arrow_up"
+    ],
+    "description": "upwards black arrow",
+    "tags": [],
+    "emoji": "⬆"
+  },
+  {
+    "aliases": [
+      "tram"
+    ],
+    "description": "tram",
+    "tags": [],
+    "emoji": "🚊"
+  },
+  {
+    "aliases": [
+      "money_face",
+      "money_mouth",
+      "money_mouth_face"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "money-mouth face",
+    "tags": [],
+    "emoji": "🤑"
+  },
+  {
+    "aliases": [
+      "grey_question"
+    ],
+    "description": "white question mark ornament",
+    "tags": [],
+    "emoji": "❔"
+  },
+  {
+    "aliases": [
+      "flag-kg",
+      "kg"
+    ],
+    "emoji": "🇰🇬",
+    "description": "regional indicator symbol letter k + regional indicator symbol letter g",
+    "tags": [
+      "flag",
+      "kyrgyzstan"
+    ]
+  },
+  {
+    "aliases": [
+      "kh",
+      "flag-kh"
+    ],
+    "emoji": "🇰🇭",
+    "description": "regional indicator symbol letter k + regional indicator symbol letter h",
+    "tags": [
+      "flag",
+      "cambodia"
+    ]
+  },
+  {
+    "aliases": [
+      "ki",
+      "flag-ki"
+    ],
+    "emoji": "🇰🇮",
+    "description": "regional indicator symbol letter k + regional indicator symbol letter i",
+    "tags": [
+      "flag",
+      "kiribati"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-ke",
+      "ke"
+    ],
+    "emoji": "🇰🇪",
+    "description": "regional indicator symbol letter k + regional indicator symbol letter e",
+    "tags": [
+      "flag",
+      "kenya"
+    ]
+  },
+  {
+    "aliases": [
+      "black_left_pointing_double_triangle_with_vertical_bar"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "black left-pointing double triangle with vertical bar",
+    "tags": [],
+    "emoji": "⏮"
+  },
+  {
+    "aliases": [
+      "flag-gs"
+    ],
+    "description": "regional indicator symbol letters gs",
+    "tags": [],
+    "emoji": "🇬🇸"
+  },
+  {
+    "aliases": [
+      "flag-bj",
+      "bj"
+    ],
+    "emoji": "🇧🇯",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter j",
+    "tags": [
+      "flag",
+      "benin"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-wf"
+    ],
+    "description": "regional indicator symbol letters wf",
+    "tags": [],
+    "emoji": "🇼🇫"
+  },
+  {
+    "aliases": [
+      "knife_fork_plate",
+      "fork_knife_plate"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "fork and knife with plate",
+    "tags": [],
+    "emoji": "🍽"
+  },
+  {
+    "aliases": [
+      "hash"
+    ],
+    "description": "number sign + combining enclosing keycap",
+    "tags": [
+      "number"
+    ],
+    "emoji": "#⃣"
+  },
+  {
+    "aliases": [
+      "bellhop_bell"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "bellhop bell",
+    "tags": [],
+    "emoji": "🛎"
+  },
+  {
+    "aliases": [
+      "leo"
+    ],
+    "description": "leo",
+    "tags": [],
+    "emoji": "♌"
+  },
+  {
+    "aliases": [
+      "biohazard_symbol",
+      "biohazard",
+      "biohazard_sign"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "biohazard symbol",
+    "tags": [],
+    "emoji": "☣"
+  },
+  {
+    "aliases": [
+      "flag-ws",
+      "ws"
+    ],
+    "emoji": "🇼🇸",
+    "description": "regional indicator symbol letter w + regional indicator symbol letter s",
+    "tags": [
+      "flag",
+      "samoa"
+    ]
+  },
+  {
+    "aliases": [
+      "man-kiss-man"
+    ],
+    "description": "",
+    "tags": [],
+    "emoji": "👨‍❤️‍💋‍👨"
+  },
+  {
+    "aliases": [
+      "no_entry_sign"
+    ],
+    "description": "no entry sign",
+    "tags": [
+      "block",
+      "forbidden"
+    ],
+    "emoji": "🚫"
+  },
+  {
+    "aliases": [
+      "flag-sh"
+    ],
+    "description": "regional indicator symbol letters sh",
+    "tags": [],
+    "emoji": "🇸🇭"
+  },
+  {
+    "aliases": [
+      "si",
+      "flag-si"
+    ],
+    "emoji": "🇸🇮",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter i",
+    "tags": [
+      "flag",
+      "slovenia"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-sj"
+    ],
+    "description": "regional indicator symbol letters sj",
+    "tags": [],
+    "emoji": "🇸🇯"
+  },
+  {
+    "aliases": [
+      "sc",
+      "flag-sc"
+    ],
+    "emoji": "🇸🇨",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter c",
+    "tags": [
+      "flag",
+      "seychelles"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-sd",
+      "sd"
+    ],
+    "emoji": "🇸🇩",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter d",
+    "tags": [
+      "flag",
+      "sudan"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-se",
+      "se"
+    ],
+    "emoji": "🇸🇪",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter e",
+    "tags": [
+      "flag",
+      "sweden"
+    ]
+  },
+  {
+    "aliases": [
+      "sa",
+      "flag-sa"
+    ],
+    "emoji": "🇸🇦",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter a",
+    "tags": [
+      "flag",
+      "saudi arabia"
+    ]
+  },
+  {
+    "aliases": [
+      "sb",
+      "flag-sb"
+    ],
+    "emoji": "🇸🇧",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter b",
+    "tags": [
+      "flag",
+      "solomon islands"
+    ]
+  },
+  {
+    "aliases": [
+      "anchor"
+    ],
+    "description": "anchor",
+    "tags": [
+      "ship"
+    ],
+    "emoji": "⚓"
+  },
+  {
+    "aliases": [
+      "eye_in_speech_bubble",
+      "i_am_a_witness"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "eye in speech bubble",
+    "tags": [],
+    "emoji": "👁‍🗨"
+  },
+  {
+    "aliases": [
+      "zero"
+    ],
+    "description": "digit zero + combining enclosing keycap",
+    "tags": [],
+    "emoji": "0⃣"
+  },
+  {
+    "aliases": [
+      "sy",
+      "flag-sy"
+    ],
+    "emoji": "🇸🇾",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter y",
+    "tags": [
+      "flag",
+      "syria"
+    ]
+  },
+  {
+    "aliases": [
+      "sz",
+      "flag-sz"
+    ],
+    "emoji": "🇸🇿",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter z",
+    "tags": [
+      "flag",
+      "swaziland"
+    ]
+  },
+  {
+    "aliases": [
+      "ss",
+      "flag-ss"
+    ],
+    "emoji": "🇸🇸",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter s",
+    "tags": [
+      "flag",
+      "south sudan"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-st",
+      "st"
+    ],
+    "emoji": "🇸🇹",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter t",
+    "tags": [
+      "flag",
+      "sao tome and principe"
+    ]
+  },
+  {
+    "aliases": [
+      "skier"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "skier",
+    "tags": [],
+    "emoji": "⛷"
+  },
+  {
+    "aliases": [
+      "flag-sv",
+      "sv"
+    ],
+    "emoji": "🇸🇻",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter v",
+    "tags": [
+      "flag",
+      "el salvador"
+    ]
+  },
+  {
+    "aliases": [
+      "pisces"
+    ],
+    "description": "pisces",
+    "tags": [],
+    "emoji": "♓"
+  },
+  {
+    "aliases": [
+      "sr",
+      "flag-sr"
+    ],
+    "emoji": "🇸🇷",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter r",
+    "tags": [
+      "flag",
+      "suriname"
+    ]
+  },
+  {
+    "aliases": [
+      "sk",
+      "flag-sk"
+    ],
+    "emoji": "🇸🇰",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter k",
+    "tags": [
+      "flag",
+      "slovakia"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-sl",
+      "sl"
+    ],
+    "emoji": "🇸🇱",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter l",
+    "tags": [
+      "flag",
+      "sierra leone"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-sm",
+      "sm"
+    ],
+    "emoji": "🇸🇲",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter m",
+    "tags": [
+      "flag",
+      "san marino"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-sn",
+      "sn"
+    ],
+    "emoji": "🇸🇳",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter n",
+    "tags": [
+      "flag",
+      "senegal"
+    ]
+  },
+  {
+    "aliases": [
+      "repeat"
+    ],
+    "description": "clockwise rightwards and leftwards open circle arrows",
+    "tags": [
+      "loop"
+    ],
+    "emoji": "🔁"
+  },
+  {
+    "aliases": [
+      "arrow_left"
+    ],
+    "description": "leftwards black arrow",
+    "tags": [],
+    "emoji": "⬅"
+  },
+  {
+    "aliases": [
+      "bf",
+      "flag-bf"
+    ],
+    "emoji": "🇧🇫",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter f",
+    "tags": [
+      "flag",
+      "burkina faso"
+    ]
+  },
+  {
+    "aliases": [
+      "heavy_multiplication_x"
+    ],
+    "description": "heavy multiplication x",
+    "tags": [],
+    "emoji": "✖"
+  },
+  {
+    "aliases": [
+      "writing_hand",
+      "writing"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "writing hand",
+    "tags": [],
+    "emoji": "✍"
+  },
+  {
+    "aliases": [
+      "two"
+    ],
+    "description": "digit two + combining enclosing keycap",
+    "tags": [],
+    "emoji": "2⃣"
+  },
+  {
+    "aliases": [
+      "hot_weather",
+      "temperature",
+      "thermometer"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "thermometer",
+    "tags": [],
+    "emoji": "🌡"
+  },
+  {
+    "aliases": [
+      "shamrock",
+      "st_patrick"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "shamrock",
+    "tags": [],
+    "emoji": "☘"
+  },
+  {
+    "aliases": [
+      "cy",
+      "flag-cy"
+    ],
+    "emoji": "🇨🇾",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter y",
+    "tags": [
+      "flag",
+      "cyprus"
+    ]
+  },
+  {
+    "aliases": [
+      "latin_cross",
+      "christian_cross"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "latin cross",
+    "tags": [],
+    "emoji": "✝"
+  },
+  {
+    "aliases": [
+      "fleur_de_lis",
+      "scouts"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "fleur-de-lis",
+    "tags": [],
+    "emoji": "⚜"
+  },
+  {
+    "aliases": [
+      "moneybag"
+    ],
+    "description": "money bag",
+    "tags": [
+      "dollar",
+      "cream"
+    ],
+    "emoji": "💰"
+  },
+  {
+    "aliases": [
+      "a"
+    ],
+    "description": "negative squared latin capital letter a",
+    "tags": [],
+    "emoji": "🅰"
+  },
+  {
+    "aliases": [
+      "flag-im"
+    ],
+    "description": "regional indicator symbol letters im",
+    "tags": [],
+    "emoji": "🇮🇲"
+  },
+  {
+    "aliases": [
+      "flag-sg",
+      "sg"
+    ],
+    "emoji": "🇸🇬",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter g",
+    "tags": [
+      "flag",
+      "singapore"
+    ]
+  },
+  {
+    "aliases": [
+      "b"
+    ],
+    "description": "negative squared latin capital letter b",
+    "tags": [],
+    "emoji": "🅱"
+  },
+  {
+    "aliases": [
+      "ge",
+      "flag-ge"
+    ],
+    "emoji": "🇬🇪",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter e",
+    "tags": [
+      "flag",
+      "georgia"
+    ]
+  },
+  {
+    "aliases": [
+      "radioactive_symbol",
+      "radioactive_sign",
+      "radioactive"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "radioactive symbol",
+    "tags": [],
+    "emoji": "☢"
+  },
+  {
+    "aliases": [
+      "o2"
+    ],
+    "description": "negative squared latin capital letter o",
+    "tags": [],
+    "emoji": "🅾"
+  },
+  {
+    "aliases": [
+      "gf",
+      "flag-gf"
+    ],
+    "emoji": "🇬🇫",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter f",
+    "tags": [
+      "flag",
+      "french guiana"
+    ]
+  },
+  {
+    "aliases": [
+      "spiral_note_pad"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "spiral note pad",
+    "tags": [],
+    "emoji": "🗒"
+  },
+  {
+    "aliases": [
+      "flag-ac"
+    ],
+    "description": "regional indicator symbol letters ac",
+    "tags": [],
+    "emoji": "🇦🇨"
+  },
+  {
+    "aliases": [
+      "arrow_forward"
+    ],
+    "description": "black right-pointing triangle",
+    "tags": [],
+    "emoji": "▶"
+  },
+  {
+    "aliases": [
+      "information_source"
+    ],
+    "description": "information source",
+    "tags": [],
+    "emoji": "ℹ"
+  },
+  {
+    "aliases": [
+      "flag-um"
+    ],
+    "description": "regional indicator symbol letters um",
+    "tags": [],
+    "emoji": "🇺🇲"
+  },
+  {
+    "aliases": [
+      "doughnut"
+    ],
+    "description": "doughnut",
+    "tags": [],
+    "emoji": "🍩"
+  },
+  {
+    "aliases": [
+      "flag-gh",
+      "gh"
+    ],
+    "emoji": "🇬🇭",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter h",
+    "tags": [
+      "flag",
+      "ghana"
+    ]
+  },
+  {
+    "aliases": [
+      "devil_fingers",
+      "heavy_metal",
+      "sign_of_the_horns",
+      "the_horns",
+      "horns_sign",
+      "rock_on"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "sign of the horns",
+    "tags": [],
+    "emoji": "🤘"
+  },
+  {
+    "aliases": [
+      "bd",
+      "flag-bd"
+    ],
+    "emoji": "🇧🇩",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter d",
+    "tags": [
+      "flag",
+      "bangladesh"
+    ]
+  },
+  {
     "aliases": [
       "rolled_up_newspaper",
       "newspaper_delivery"
     ],
-    "tags": []
+    "supports_fitzpatrick": false,
+    "description": "newspaper rolled up for delivery",
+    "tags": [],
+    "emoji": "🗞"
   },
   {
-    "emoji": "🗳",
-    "description": "ballot bow with ballot",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "ballot",
-      "ballot_box"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🖋",
-    "description": "lower left fountain pen",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "lower_left_fountain_pen"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🖊",
-    "description": "lower left ballpoint pen",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "lower_left_ballpoint_pen"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🖌",
-    "description": "lower left paintbrush",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "lower_left_paintbrush"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🖍",
-    "description": "lower left crayon",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "lower_left_crayon"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🗂",
-    "description": "card index dividers",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "card_index_dividers"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🗒",
-    "description": "spiral note pad",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "spiral_note_pad"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🗓",
-    "description": "spiral calendar pad",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "spiral_calendar_pad"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🖇",
-    "description": "multiple paperclips linked together",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "linked_paperclips"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🗃",
-    "description": "card file box",
-    "supports_fitzpatrick": false,
-    "aliases": [
-      "card_file_box"
-    ],
-    "tags": []
-  },
-  {
-    "emoji": "🗄",
-    "description": "file cabinet",
-    "supports_fitzpatrick": false,
     "aliases": [
       "file_cabinet"
     ],
-    "tags": []
+    "supports_fitzpatrick": false,
+    "description": "file cabinet",
+    "tags": [],
+    "emoji": "🗄"
   },
   {
-    "emoji": "🗑",
-    "description": "wastebasket",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "wastebasket"
+      "admission_ticket",
+      "admission_tickets"
     ],
-    "tags": []
+    "supports_fitzpatrick": false,
+    "description": "admission ticket",
+    "tags": [],
+    "emoji": "🎟"
   },
   {
-    "emoji": "🗝",
-    "description": "an ornate old key",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "old_key"
+      "flag-vu",
+      "vu"
     ],
-    "tags": []
+    "emoji": "🇻🇺",
+    "description": "regional indicator symbol letter v + regional indicator symbol letter u",
+    "tags": [
+      "flag",
+      "vanuatu"
+    ]
   },
   {
-    "emoji": "⛏",
-    "description": "pick",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "pick"
+      "orthodox_cross"
     ],
-    "tags": []
+    "supports_fitzpatrick": false,
+    "description": "orthodox cross",
+    "tags": [],
+    "emoji": "☦"
   },
   {
-    "emoji": "⚒",
-    "description": "hammer and pick",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "hammer_and_pick"
+      "man-man-girl",
+      "family_man_man_girl"
     ],
-    "tags": []
+    "description": "family (man, man, girl)",
+    "tags": [
+      "family",
+      "man",
+      "girl"
+    ],
+    "emoji": "👨‍👨‍👧"
   },
   {
-    "emoji": "🛠",
-    "description": "hammer and wrench",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "hammer_and_wrench"
+      "o"
     ],
-    "tags": []
+    "description": "heavy large circle",
+    "tags": [],
+    "emoji": "⭕"
   },
   {
-    "emoji": "⚙",
-    "description": "gear",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "gear"
+      "scorpius"
     ],
-    "tags": []
+    "description": "scorpius",
+    "tags": [],
+    "emoji": "♏"
   },
   {
-    "emoji": "🗜",
-    "description": "compression",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "compression"
+      "flag-uz",
+      "uz"
     ],
-    "tags": []
+    "emoji": "🇺🇿",
+    "description": "regional indicator symbol letter u + regional indicator symbol letter z",
+    "tags": [
+      "flag",
+      "uzbekistan"
+    ]
   },
   {
-    "emoji": "⚗",
-    "description": "alembic",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "alembic"
+      "black_small_square"
     ],
-    "tags": []
+    "description": "black small square",
+    "tags": [],
+    "emoji": "▪"
   },
   {
-    "emoji": "⚖",
-    "description": "scales of justice",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "scales",
-      "scales_of_justice"
+      "rewind"
     ],
-    "tags": []
+    "description": "black left-pointing double triangle",
+    "tags": [],
+    "emoji": "⏪"
   },
   {
-    "emoji": "⛓",
-    "description": "chains",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "chains"
+      "skin-tone-5"
     ],
-    "tags": []
+    "description": "emoji modifier fitzpatrick type-5",
+    "tags": [],
+    "emoji": "🏾"
   },
   {
-    "emoji": "🗡",
-    "description": "dagger knife",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "dagger",
-      "dagger_knife",
-      "knife_weapon"
+      "minibus"
     ],
-    "tags": []
+    "description": "minibus",
+    "tags": [],
+    "emoji": "🚐"
   },
   {
-    "emoji": "⚔",
-    "description": "crossed swords",
+    "aliases": [
+      "flag-us",
+      "us"
+    ],
+    "emoji": "🇺🇸",
+    "description": "regional indicator symbol letter u + regional indicator symbol letter s",
+    "tags": [
+      "flag",
+      "united states of america"
+    ]
+  },
+  {
+    "aliases": [
+      "oncoming_taxi"
+    ],
+    "description": "oncoming taxi",
+    "tags": [],
+    "emoji": "🚖"
+  },
+  {
+    "aliases": [
+      "grey_exclamation"
+    ],
+    "description": "white exclamation mark ornament",
+    "tags": [],
+    "emoji": "❕"
+  },
+  {
+    "aliases": [
+      "to",
+      "flag-to"
+    ],
+    "emoji": "🇹🇴",
+    "description": "regional indicator symbol letter t + regional indicator symbol letter o",
+    "tags": [
+      "flag",
+      "tonga"
+    ]
+  },
+  {
+    "aliases": [
+      "family_man_woman_boy"
+    ],
+    "description": "family (man, woman, boy)",
+    "tags": [
+      "family",
+      "man",
+      "woman",
+      "boy"
+    ],
+    "emoji": "👨‍👩‍👦"
+  },
+  {
+    "aliases": [
+      "thermometer_face",
+      "ill",
+      "face_with_thermometer",
+      "sick"
+    ],
     "supports_fitzpatrick": false,
+    "description": "face with thermometer",
+    "tags": [],
+    "emoji": "🤒"
+  },
+  {
+    "aliases": [
+      "flag-th",
+      "th"
+    ],
+    "emoji": "🇹🇭",
+    "description": "regional indicator symbol letter t + regional indicator symbol letter h",
+    "tags": [
+      "flag",
+      "thailand"
+    ]
+  },
+  {
+    "aliases": [
+      "no_entry"
+    ],
+    "description": "no entry",
+    "tags": [
+      "limit"
+    ],
+    "emoji": "⛔"
+  },
+  {
+    "aliases": [
+      "flag-cw",
+      "cw"
+    ],
+    "emoji": "🇨🇼",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter w",
+    "tags": [
+      "flag",
+      "curacao"
+    ]
+  },
+  {
+    "aliases": [
+      "open_umbrella",
+      "umbrella"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "open umbrella",
+    "tags": [],
+    "emoji": "☂"
+  },
+  {
+    "aliases": [
+      "v"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "victory hand",
+    "tags": [
+      "victory",
+      "peace"
+    ],
+    "emoji": "✌"
+  },
+  {
+    "aliases": [
+      "injured",
+      "face_with_head_bandage",
+      "head_bandaged",
+      "bandaged",
+      "head_bandage"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "face with head bandage",
+    "tags": [],
+    "emoji": "🤕"
+  },
+  {
+    "aliases": [
+      "flag-eh"
+    ],
+    "description": "regional indicator symbol letters eh",
+    "tags": [],
+    "emoji": "🇪🇭"
+  },
+  {
+    "aliases": [
+      "world_map"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "world map",
+    "tags": [],
+    "emoji": "🗺"
+  },
+  {
+    "aliases": [
+      "ambulance"
+    ],
+    "description": "ambulance",
+    "tags": [],
+    "emoji": "🚑"
+  },
+  {
+    "aliases": [
+      "heavy_division_sign"
+    ],
+    "description": "heavy division sign",
+    "tags": [],
+    "emoji": "➗"
+  },
+  {
+    "aliases": [
+      "ab"
+    ],
+    "description": "negative squared ab",
+    "tags": [],
+    "emoji": "🆎"
+  },
+  {
+    "aliases": [
+      "clubs"
+    ],
+    "description": "black club suit",
+    "tags": [],
+    "emoji": "♣"
+  },
+  {
+    "aliases": [
+      "hugging_face",
+      "hug",
+      "hugging",
+      "hugs"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "hugging face",
+    "tags": [],
+    "emoji": "🤗"
+  },
+  {
+    "aliases": [
+      "flag-bi",
+      "bi"
+    ],
+    "emoji": "🇧🇮",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter i",
+    "tags": [
+      "flag",
+      "burundi"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-pn"
+    ],
+    "description": "regional indicator symbol letters pn",
+    "tags": [],
+    "emoji": "🇵🇳"
+  },
+  {
+    "aliases": [
+      "fireworks"
+    ],
+    "description": "fireworks",
+    "tags": [
+      "festival",
+      "celebration"
+    ],
+    "emoji": "🎆"
+  },
+  {
+    "aliases": [
+      "white_flower"
+    ],
+    "description": "white flower",
+    "tags": [],
+    "emoji": "💮"
+  },
+  {
+    "aliases": [
+      "man-woman-boy-boy",
+      "family_man_woman_boy_boy"
+    ],
+    "description": "family (man, woman, boy, boy)",
+    "tags": [
+      "family",
+      "man",
+      "woman",
+      "boy"
+    ],
+    "emoji": "👨‍👩‍👦‍👦"
+  },
+  {
+    "aliases": [
+      "couplekiss_man_man"
+    ],
+    "description": "kiss (man, man)",
+    "tags": [
+      "couple",
+      "kiss",
+      "man"
+    ],
+    "emoji": "👨‍❤‍💋‍👨"
+  },
+  {
+    "aliases": [
+      "copyright"
+    ],
+    "description": "copyright sign",
+    "tags": [],
+    "emoji": "©"
+  },
+  {
+    "aliases": [
+      "white_small_square"
+    ],
+    "description": "white small square",
+    "tags": [],
+    "emoji": "▫"
+  },
+  {
+    "aliases": [
+      "flag-cv",
+      "cv"
+    ],
+    "emoji": "🇨🇻",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter v",
+    "tags": [
+      "flag",
+      "cape verde"
+    ]
+  },
+  {
+    "aliases": [
+      "christmas_tree"
+    ],
+    "description": "christmas tree",
+    "tags": [],
+    "emoji": "🎄"
+  },
+  {
+    "aliases": [
+      "ok_woman"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "face with ok gesture",
+    "tags": [],
+    "emoji": "🙆"
+  },
+  {
+    "aliases": [
+      "woman-woman-boy-boy",
+      "family_woman_woman_boy_boy"
+    ],
+    "description": "family (woman, woman, boy, boy)",
+    "tags": [
+      "family",
+      "woman",
+      "boy"
+    ],
+    "emoji": "👩‍👩‍👦‍👦"
+  },
+  {
+    "aliases": [
+      "flag-pf"
+    ],
+    "description": "regional indicator symbol letters pf",
+    "tags": [],
+    "emoji": "🇵🇫"
+  },
+  {
+    "aliases": [
+      "slightly_frowning",
+      "slightly_frowning_face"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "slightly frowning face",
+    "tags": [],
+    "emoji": "🙁"
+  },
+  {
+    "aliases": [
+      "flag-bh",
+      "bh"
+    ],
+    "emoji": "🇧🇭",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter h",
+    "tags": [
+      "flag",
+      "bahrain"
+    ]
+  },
+  {
+    "aliases": [
+      "soccer"
+    ],
+    "description": "soccer ball",
+    "tags": [
+      "sports"
+    ],
+    "emoji": "⚽"
+  },
+  {
+    "aliases": [
+      "flag-in",
+      "in"
+    ],
+    "emoji": "🇮🇳",
+    "description": "regional indicator symbol letter i + regional indicator symbol letter n",
+    "tags": [
+      "flag",
+      "india"
+    ]
+  },
+  {
+    "aliases": [
+      "jack_o_lantern"
+    ],
+    "description": "jack-o-lantern",
+    "tags": [
+      "halloween"
+    ],
+    "emoji": "🎃"
+  },
+  {
     "aliases": [
       "crossed_swords"
     ],
-    "tags": []
+    "supports_fitzpatrick": false,
+    "description": "crossed swords",
+    "tags": [],
+    "emoji": "⚔"
   },
   {
-    "emoji": "🛡",
-    "description": "shield",
+    "aliases": [
+      "traffic_light"
+    ],
+    "description": "horizontal traffic light",
+    "tags": [],
+    "emoji": "🚥"
+  },
+  {
+    "aliases": [
+      "flipped_face",
+      "upside_down_face",
+      "upside_down"
+    ],
     "supports_fitzpatrick": false,
+    "description": "upside-down face",
+    "tags": [],
+    "emoji": "🙃"
+  },
+  {
+    "aliases": [
+      "shopping_bags"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "shopping bags",
+    "tags": [],
+    "emoji": "🛍"
+  },
+  {
+    "aliases": [
+      "slightly_smiling",
+      "slightly_smiling_face"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "slightly smiling face",
+    "tags": [],
+    "emoji": "🙂"
+  },
+  {
+    "aliases": [
+      "x"
+    ],
+    "description": "cross mark",
+    "tags": [],
+    "emoji": "❌"
+  },
+  {
+    "aliases": [
+      "eject"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "eject button",
+    "tags": [],
+    "emoji": "⏏"
+  },
+  {
+    "aliases": [
+      "person_frowning"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "person frowning",
+    "tags": [
+      "sad"
+    ],
+    "emoji": "🙍"
+  },
+  {
+    "aliases": [
+      "aquarius"
+    ],
+    "description": "aquarius",
+    "tags": [],
+    "emoji": "♒"
+  },
+  {
+    "aliases": [
+      "flag-tl",
+      "tl"
+    ],
+    "emoji": "🇹🇱",
+    "description": "regional indicator symbol letter t + regional indicator symbol letter l",
+    "tags": [
+      "flag",
+      "east timor"
+    ]
+  },
+  {
+    "aliases": [
+      "flags"
+    ],
+    "description": "carp streamer",
+    "tags": [],
+    "emoji": "🎏"
+  },
+  {
+    "aliases": [
+      "bg",
+      "flag-bg"
+    ],
+    "emoji": "🇧🇬",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter g",
+    "tags": [
+      "flag",
+      "bulgaria"
+    ]
+  },
+  {
+    "aliases": [
+      "crossed_flags"
+    ],
+    "description": "crossed flags",
+    "tags": [],
+    "emoji": "🎌"
+  },
+  {
+    "aliases": [
+      "ballot_box_with_check"
+    ],
+    "description": "ballot box with check",
+    "tags": [],
+    "emoji": "☑"
+  },
+  {
+    "aliases": [
+      "person_with_pouting_face"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "person with pouting face",
+    "tags": [],
+    "emoji": "🙎"
+  },
+  {
+    "aliases": [
+      "confetti_ball"
+    ],
+    "description": "confetti ball",
+    "tags": [],
+    "emoji": "🎊"
+  },
+  {
+    "aliases": [
+      "hammer_and_pick"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "hammer and pick",
+    "tags": [],
+    "emoji": "⚒"
+  },
+  {
     "aliases": [
       "shield"
     ],
-    "tags": []
+    "supports_fitzpatrick": false,
+    "description": "shield",
+    "tags": [],
+    "emoji": "🛡"
   },
   {
-    "emoji": "🏹",
-    "description": "bow and arrow",
+    "aliases": [
+      "black_right_pointing_triangle_with_double_vertical_bar"
+    ],
     "supports_fitzpatrick": false,
+    "description": "black right-pointing triangle with double vertical bar",
+    "tags": [],
+    "emoji": "⏯"
+  },
+  {
+    "aliases": [
+      "tanabata_tree"
+    ],
+    "description": "tanabata tree",
+    "tags": [],
+    "emoji": "🎋"
+  },
+  {
+    "aliases": [
+      "lower_left_fountain_pen"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "lower left fountain pen",
+    "tags": [],
+    "emoji": "🖋"
+  },
+  {
+    "aliases": [
+      "flag-tk"
+    ],
+    "description": "regional indicator symbol letters tk",
+    "tags": [],
+    "emoji": "🇹🇰"
+  },
+  {
+    "aliases": [
+      "balloon"
+    ],
+    "description": "balloon",
+    "tags": [
+      "party",
+      "birthday"
+    ],
+    "emoji": "🎈"
+  },
+  {
+    "aliases": [
+      "wheel_of_dharma"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "wheel of Dharma",
+    "tags": [],
+    "emoji": "☸"
+  },
+  {
+    "aliases": [
+      "white_medium_square"
+    ],
+    "description": "white medium square",
+    "tags": [],
+    "emoji": "◻"
+  },
+  {
+    "aliases": [
+      "tada"
+    ],
+    "description": "party popper",
+    "tags": [
+      "party"
+    ],
+    "emoji": "🎉"
+  },
+  {
+    "aliases": [
+      "fuelpump"
+    ],
+    "description": "fuel pump",
+    "tags": [],
+    "emoji": "⛽"
+  },
+  {
+    "aliases": [
+      "flag-cd",
+      "cd"
+    ],
+    "emoji": "🇨🇩",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter d",
+    "tags": [
+      "flag",
+      "democratic republic of the congo"
+    ]
+  },
+  {
+    "aliases": [
+      "label"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "label",
+    "tags": [],
+    "emoji": "🏷"
+  },
+  {
+    "aliases": [
+      "police_car"
+    ],
+    "description": "police car",
+    "tags": [],
+    "emoji": "🚓"
+  },
+  {
+    "aliases": [
+      "scales_of_justice",
+      "scales"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "scales of justice",
+    "tags": [],
+    "emoji": "⚖"
+  },
+  {
+    "aliases": [
+      "waving_black_flag"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "waving black flag",
+    "tags": [],
+    "emoji": "🏴"
+  },
+  {
+    "aliases": [
+      "pg",
+      "flag-pg"
+    ],
+    "emoji": "🇵🇬",
+    "description": "regional indicator symbol letter p + regional indicator symbol letter g",
+    "tags": [
+      "flag",
+      "papua new guinea"
+    ]
+  },
+  {
+    "aliases": [
+      "tn",
+      "flag-tn"
+    ],
+    "emoji": "🇹🇳",
+    "description": "regional indicator symbol letter t + regional indicator symbol letter n",
+    "tags": [
+      "flag",
+      "tunisia"
+    ]
+  },
+  {
+    "aliases": [
+      "rosette"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "rosette",
+    "tags": [],
+    "emoji": "🏵"
+  },
+  {
+    "aliases": [
+      "warning"
+    ],
+    "description": "warning sign",
+    "tags": [
+      "wip"
+    ],
+    "emoji": "⚠"
+  },
+  {
+    "aliases": [
+      "point_up"
+    ],
+    "description": "white up pointing index",
+    "tags": [],
+    "emoji": "☝"
+  },
+  {
+    "aliases": [
+      "black_large_square"
+    ],
+    "description": "black large square",
+    "tags": [],
+    "emoji": "⬛"
+  },
+  {
+    "aliases": [
+      "heavy_dollar_sign"
+    ],
+    "description": "heavy dollar sign",
+    "tags": [],
+    "emoji": "💲"
+  },
+  {
+    "aliases": [
+      "waving_white_flag"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "waving white flag",
+    "tags": [],
+    "emoji": "🏳"
+  },
+  {
+    "aliases": [
+      "european_castle"
+    ],
+    "description": "european castle",
+    "tags": [],
+    "emoji": "🏰"
+  },
+  {
+    "aliases": [
+      "flag-je"
+    ],
+    "description": "regional indicator symbol letters je",
+    "tags": [],
+    "emoji": "🇯🇪"
+  },
+  {
+    "aliases": [
+      "stopwatch"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "stopwatch",
+    "tags": [],
+    "emoji": "⏱"
+  },
+  {
+    "aliases": [
+      "dagger",
+      "knife_weapon",
+      "dagger_knife"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "dagger knife",
+    "tags": [],
+    "emoji": "🗡"
+  },
+  {
+    "aliases": [
+      "arrows_clockwise"
+    ],
+    "description": "clockwise downwards and upwards open circle arrows",
+    "tags": [],
+    "emoji": "🔃"
+  },
+  {
+    "aliases": [
+      "registered"
+    ],
+    "description": "registered sign",
+    "tags": [],
+    "emoji": "®"
+  },
+  {
+    "aliases": [
+      "champagne",
+      "sparkling_wine"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "bottle with popping cork",
+    "tags": [],
+    "emoji": "🍾"
+  },
+  {
+    "aliases": [
+      "timer_clock"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "timer clock",
+    "tags": [],
+    "emoji": "⏲"
+  },
+  {
+    "aliases": [
+      "joystick"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "joystick",
+    "tags": [],
+    "emoji": "🕹"
+  },
+  {
+    "aliases": [
+      "eight"
+    ],
+    "description": "digit eight + combining enclosing keycap",
+    "tags": [],
+    "emoji": "8⃣"
+  },
+  {
+    "aliases": [
+      "building_construction",
+      "crane"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "building in construction with crane",
+    "tags": [],
+    "emoji": "🏗"
+  },
+  {
+    "aliases": [
+      "skin-tone-3"
+    ],
+    "description": "emoji modifier fitzpatrick type-3",
+    "tags": [],
+    "emoji": "🏼"
+  },
+  {
+    "aliases": [
+      "woman-heart-woman"
+    ],
+    "description": "",
+    "tags": [],
+    "emoji": "👩‍❤️‍👩"
+  },
+  {
+    "aliases": [
+      "ferry"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "ferry",
+    "tags": [],
+    "emoji": "⛴"
+  },
+  {
+    "aliases": [
+      "arrow_backward"
+    ],
+    "description": "black left-pointing triangle",
+    "tags": [],
+    "emoji": "◀"
+  },
+  {
+    "aliases": [
+      "six"
+    ],
+    "description": "digit six + combining enclosing keycap",
+    "tags": [],
+    "emoji": "6⃣"
+  },
+  {
+    "aliases": [
+      "sparkle"
+    ],
+    "description": "sparkle",
+    "tags": [],
+    "emoji": "❇"
+  },
+  {
+    "aliases": [
+      "interrobang"
+    ],
+    "description": "exclamation question mark",
+    "tags": [],
+    "emoji": "⁉"
+  },
+  {
+    "aliases": [
+      "suspension_railway"
+    ],
+    "description": "suspension railway",
+    "tags": [],
+    "emoji": "🚟"
+  },
+  {
+    "aliases": [
+      "virgo"
+    ],
+    "description": "virgo",
+    "tags": [],
+    "emoji": "♍"
+  },
+  {
+    "aliases": [
+      "skin-tone-2"
+    ],
+    "description": "emoji modifier fitzpatrick type-1-2",
+    "tags": [],
+    "emoji": "🏻"
+  },
+  {
+    "aliases": [
+      "tv",
+      "flag-tv"
+    ],
+    "emoji": "🇹🇻",
+    "description": "regional indicator symbol letter t + regional indicator symbol letter v",
+    "tags": [
+      "flag",
+      "tuvalu"
+    ]
+  },
+  {
+    "aliases": [
+      "hk",
+      "flag-hk"
+    ],
+    "emoji": "🇭🇰",
+    "description": "regional indicator symbol letter h + regional indicator symbol letter k",
+    "tags": [
+      "flag",
+      "hong kong"
+    ]
+  },
+  {
+    "aliases": [
+      "hn",
+      "flag-hn"
+    ],
+    "emoji": "🇭🇳",
+    "description": "regional indicator symbol letter h + regional indicator symbol letter n",
+    "tags": [
+      "flag",
+      "honduras"
+    ]
+  },
+  {
+    "aliases": [
+      "at",
+      "flag-at"
+    ],
+    "emoji": "🇦🇹",
+    "description": "regional indicator symbol letter a + regional indicator symbol letter t",
+    "tags": [
+      "flag",
+      "austria"
+    ]
+  },
+  {
+    "aliases": [
+      "badminton_racquet_and_shuttlecock",
+      "badminton"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "badminton racket and shuttlecock",
+    "tags": [],
+    "emoji": "🏸"
+  },
+  {
+    "aliases": [
+      "exclamation",
+      "heavy_exclamation_mark"
+    ],
+    "description": "heavy exclamation mark symbol",
+    "tags": [
+      "bang"
+    ],
+    "emoji": "❗"
+  },
+  {
+    "aliases": [
+      "flag-ht",
+      "ht"
+    ],
+    "emoji": "🇭🇹",
+    "description": "regional indicator symbol letter h + regional indicator symbol letter t",
+    "tags": [
+      "flag",
+      "haiti"
+    ]
+  },
+  {
+    "aliases": [
+      "woman-woman-girl-boy",
+      "family_woman_woman_girl_boy"
+    ],
+    "description": "family (woman, woman, girl, boy)",
+    "tags": [
+      "family",
+      "woman",
+      "girl",
+      "boy"
+    ],
+    "emoji": "👩‍👩‍👧‍👦"
+  },
+  {
+    "aliases": [
+      "left_luggage"
+    ],
+    "description": "left luggage",
+    "tags": [],
+    "emoji": "🛅"
+  },
+  {
+    "aliases": [
+      "negative_squared_cross_mark"
+    ],
+    "description": "negative squared cross mark",
+    "tags": [],
+    "emoji": "❎"
+  },
+  {
+    "aliases": [
+      "bank"
+    ],
+    "description": "bank",
+    "tags": [],
+    "emoji": "🏦"
+  },
+  {
+    "aliases": [
+      "black_circle_for_record"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "black circle for record",
+    "tags": [],
+    "emoji": "⏺"
+  },
+  {
+    "aliases": [
+      "atm"
+    ],
+    "description": "automated teller machine",
+    "tags": [],
+    "emoji": "🏧"
+  },
+  {
+    "aliases": [
+      "flag-jp",
+      "jp"
+    ],
+    "emoji": "🇯🇵",
+    "description": "regional indicator symbol letter j + regional indicator symbol letter p",
+    "tags": [
+      "flag",
+      "japan"
+    ]
+  },
+  {
+    "aliases": [
+      "dj",
+      "flag-dj"
+    ],
+    "emoji": "🇩🇯",
+    "description": "regional indicator symbol letter d + regional indicator symbol letter j",
+    "tags": [
+      "flag",
+      "djibouti"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-tw"
+    ],
+    "description": "regional indicator symbol letters tw",
+    "tags": [],
+    "emoji": "🇹🇼"
+  },
+  {
+    "aliases": [
+      "european_post_office"
+    ],
+    "description": "european post office",
+    "tags": [],
+    "emoji": "🏤"
+  },
+  {
+    "aliases": [
+      "barber"
+    ],
+    "description": "barber pole",
+    "tags": [],
+    "emoji": "💈"
+  },
+  {
+    "aliases": [
+      "do",
+      "flag-do"
+    ],
+    "emoji": "🇩🇴",
+    "description": "regional indicator symbol letter d + regional indicator symbol letter o",
+    "tags": [
+      "flag",
+      "dominican republic"
+    ]
+  },
+  {
+    "aliases": [
+      "hospital"
+    ],
+    "description": "hospital",
+    "tags": [],
+    "emoji": "🏥"
+  },
+  {
+    "aliases": [
+      "wheelchair"
+    ],
+    "description": "wheelchair symbol",
+    "tags": [
+      "accessibility"
+    ],
+    "emoji": "♿"
+  },
+  {
+    "aliases": [
+      "flag-pm"
+    ],
+    "description": "regional indicator symbol letters pm",
+    "tags": [],
+    "emoji": "🇵🇲"
+  },
+  {
+    "aliases": [
+      "flag-dm",
+      "dm"
+    ],
+    "emoji": "🇩🇲",
+    "description": "regional indicator symbol letter d + regional indicator symbol letter m",
+    "tags": [
+      "flag",
+      "dominica"
+    ]
+  },
+  {
+    "aliases": [
+      "amphora",
+      "jar",
+      "vase"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "amphora",
+    "tags": [],
+    "emoji": "🏺"
+  },
+  {
+    "aliases": [
+      "office"
+    ],
+    "description": "office building",
+    "tags": [],
+    "emoji": "🏢"
+  },
+  {
+    "aliases": [
+      "dz",
+      "flag-dz"
+    ],
+    "emoji": "🇩🇿",
+    "description": "regional indicator symbol letter d + regional indicator symbol letter z",
+    "tags": [
+      "flag",
+      "algeria"
+    ]
+  },
+  {
+    "aliases": [
+      "black_medium_small_square"
+    ],
+    "description": "black medium small square",
+    "tags": [],
+    "emoji": "◾"
+  },
+  {
+    "aliases": [
+      "post_office"
+    ],
+    "description": "japanese post office",
+    "tags": [],
+    "emoji": "🏣"
+  },
+  {
+    "aliases": [
+      "sunny"
+    ],
+    "description": "black sun with rays",
+    "tags": [
+      "weather"
+    ],
+    "emoji": "☀"
+  },
+  {
+    "aliases": [
+      "al",
+      "flag-al"
+    ],
+    "emoji": "🇦🇱",
+    "description": "regional indicator symbol letter a + regional indicator symbol letter l",
+    "tags": [
+      "flag",
+      "albania"
+    ]
+  },
+  {
+    "aliases": [
+      "house"
+    ],
+    "description": "house building",
+    "tags": [],
+    "emoji": "🏠"
+  },
+  {
+    "aliases": [
+      "tz",
+      "flag-tz"
+    ],
+    "emoji": "🇹🇿",
+    "description": "regional indicator symbol letter t + regional indicator symbol letter z",
+    "tags": [
+      "flag",
+      "tanzania"
+    ]
+  },
+  {
+    "aliases": [
+      "house_with_garden"
+    ],
+    "description": "house with garden",
+    "tags": [],
+    "emoji": "🏡"
+  },
+  {
+    "aliases": [
+      "lounge",
+      "couch_lamp",
+      "couch_and_lamp",
+      "sofa",
+      "couch"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "couch and lamp",
+    "tags": [],
+    "emoji": "🛋"
+  },
+  {
+    "aliases": [
+      "family_man_woman_girl",
+      "man-woman-girl"
+    ],
+    "description": "family (man, woman, girl)",
+    "tags": [
+      "family",
+      "man",
+      "woman",
+      "girl"
+    ],
+    "emoji": "👨‍👩‍👧"
+  },
+  {
+    "aliases": [
+      "izakaya_lantern",
+      "lantern"
+    ],
+    "description": "izakaya lantern",
+    "tags": [],
+    "emoji": "🏮"
+  },
+  {
+    "aliases": [
+      "dark_sunglasses"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "dark sunglasses",
+    "tags": [],
+    "emoji": "🕶"
+  },
+  {
+    "aliases": [
+      "arrow_up_down"
+    ],
+    "description": "up down arrow",
+    "tags": [],
+    "emoji": "↕"
+  },
+  {
+    "aliases": [
+      "japanese_castle"
+    ],
+    "description": "japanese castle",
+    "tags": [],
+    "emoji": "🏯"
+  },
+  {
+    "aliases": [
+      "parking"
+    ],
+    "description": "negative squared latin capital letter p",
+    "tags": [],
+    "emoji": "🅿"
+  },
+  {
+    "aliases": [
+      "couplekiss_woman_woman"
+    ],
+    "description": "kiss (woman, woman)",
+    "tags": [
+      "couple",
+      "kiss",
+      "woman"
+    ],
+    "emoji": "👩‍❤‍💋‍👩"
+  },
+  {
+    "aliases": [
+      "department_store"
+    ],
+    "description": "department store",
+    "tags": [],
+    "emoji": "🏬"
+  },
+  {
+    "aliases": [
+      "mantelpiece_clock"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "mantelpiece clock",
+    "tags": [],
+    "emoji": "🕰"
+  },
+  {
+    "aliases": [
+      "arrow_right"
+    ],
+    "description": "black rightwards arrow",
+    "tags": [],
+    "emoji": "➡"
+  },
+  {
+    "aliases": [
+      "skull_and_crossbones",
+      "skull_crossbones"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "skull and crossbones",
+    "tags": [],
+    "emoji": "☠"
+  },
+  {
+    "aliases": [
+      "factory"
+    ],
+    "description": "factory",
+    "tags": [],
+    "emoji": "🏭"
+  },
+  {
+    "aliases": [
+      "regional_indicator_symbol_r"
+    ],
+    "emoji": "🇷",
+    "description": "regional indicator symbol letter r",
+    "tags": [
+      "letter",
+      "r"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-af",
+      "af"
+    ],
+    "emoji": "🇦🇫",
+    "description": "regional indicator symbol letter a + regional indicator symbol letter f",
+    "tags": [
+      "flag",
+      "afghanistan"
+    ]
+  },
+  {
+    "aliases": [
+      "zip_it",
+      "zipper_mouth",
+      "zipper_mouth_face",
+      "sealed_lips",
+      "lips_sealed"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "zipper-mouth face",
+    "tags": [],
+    "emoji": "🤐"
+  },
+  {
+    "aliases": [
+      "convenience_store"
+    ],
+    "description": "convenience store",
+    "tags": [],
+    "emoji": "🏪"
+  },
+  {
+    "aliases": [
+      "black_circle"
+    ],
+    "description": "medium black circle",
+    "tags": [],
+    "emoji": "⚫"
+  },
+  {
+    "aliases": [
+      "nerd",
+      "nerd_face",
+      "nerdy"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "nerd face",
+    "tags": [],
+    "emoji": "🤓"
+  },
+  {
+    "aliases": [
+      "thinking",
+      "thinking_face",
+      "thinker",
+      "think"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "thinking face",
+    "tags": [],
+    "emoji": "🤔"
+  },
+  {
+    "aliases": [
+      "eight_spoked_asterisk"
+    ],
+    "description": "eight spoked asterisk",
+    "tags": [],
+    "emoji": "✳"
+  },
+  {
+    "aliases": [
+      "bot_face",
+      "robot_face"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "robot face",
+    "tags": [],
+    "emoji": "🤖"
+  },
+  {
+    "aliases": [
+      "school"
+    ],
+    "description": "school",
+    "tags": [],
+    "emoji": "🏫"
+  },
+  {
+    "aliases": [
+      "vi",
+      "flag-vi"
+    ],
+    "emoji": "🇻🇮",
+    "description": "regional indicator symbol letter v + regional indicator symbol letter i",
+    "tags": [
+      "flag",
+      "us virgin islands"
+    ]
+  },
+  {
+    "aliases": [
+      "hotel"
+    ],
+    "description": "hotel",
+    "tags": [],
+    "emoji": "🏨"
+  },
+  {
+    "aliases": [
+      "love_hotel"
+    ],
+    "description": "love hotel",
+    "tags": [],
+    "emoji": "🏩"
+  },
+  {
+    "aliases": [
+      "regional_indicator_symbol_i"
+    ],
+    "emoji": "🇮",
+    "description": "regional indicator symbol letter i",
+    "tags": [
+      "letter",
+      "i"
+    ]
+  },
+  {
+    "aliases": [
+      "beach_with_umbrella",
+      "breach"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "beach with umbrella",
+    "tags": [],
+    "emoji": "🏖"
+  },
+  {
+    "aliases": [
+      "repeat_one"
+    ],
+    "description": "clockwise rightwards and leftwards open circle arrows with circled one overlay",
+    "tags": [],
+    "emoji": "🔂"
+  },
+  {
+    "aliases": [
+      "flag-dg"
+    ],
+    "description": "regional indicator symbol letters dg",
+    "tags": [],
+    "emoji": "🇩🇬"
+  },
+  {
+    "aliases": [
+      "family_man_man_boy",
+      "man-man-boy"
+    ],
+    "description": "family (man, man, boy)",
+    "tags": [
+      "family",
+      "man",
+      "boy"
+    ],
+    "emoji": "👨‍👨‍👦"
+  },
+  {
+    "aliases": [
+      "flag-tt",
+      "tt"
+    ],
+    "emoji": "🇹🇹",
+    "description": "regional indicator symbol letter t + regional indicator symbol letter t",
+    "tags": [
+      "flag",
+      "trinidad and tobago"
+    ]
+  },
+  {
+    "aliases": [
+      "mens"
+    ],
+    "description": "mens symbol",
+    "tags": [],
+    "emoji": "🚹"
+  },
+  {
+    "aliases": [
+      "crab",
+      "cancer"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "red crab",
+    "tags": [],
+    "emoji": "🦀"
+  },
+  {
+    "aliases": [
+      "mont_fuji",
+      "snow_capped_mountain"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "snow capped mountain",
+    "tags": [],
+    "emoji": "🏔"
+  },
+  {
+    "aliases": [
+      "arrows_counterclockwise"
+    ],
+    "description": "anticlockwise downwards and upwards open circle arrows",
+    "tags": [
+      "sync"
+    ],
+    "emoji": "🔄"
+  },
+  {
+    "aliases": [
+      "sagittarius"
+    ],
+    "description": "sagittarius",
+    "tags": [],
+    "emoji": "♐"
+  },
+  {
+    "aliases": [
+      "campsite",
+      "camping",
+      "tent"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "camping with tent and tree",
+    "tags": [],
+    "emoji": "🏕"
+  },
+  {
+    "aliases": [
+      "ice_hockey",
+      "ice_hockey_stick_and_puck"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "ice hockey stick and puck",
+    "tags": [],
+    "emoji": "🏒"
+  },
+  {
+    "aliases": [
+      "picture_frame",
+      "painting",
+      "gallery",
+      "frame_with_picture"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "frame with picture or painting",
+    "tags": [],
+    "emoji": "🖼"
+  },
+  {
+    "aliases": [
+      "table_tennis_paddle_and_ball",
+      "ping_pong",
+      "table_tennis"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "table tennis paddle and ball",
+    "tags": [],
+    "emoji": "🏓"
+  },
+  {
+    "aliases": [
+      "flag-tm",
+      "tm"
+    ],
+    "emoji": "🇹🇲",
+    "description": "regional indicator symbol letter t + regional indicator symbol letter m",
+    "tags": [
+      "flag",
+      "turkmenistan"
+    ]
+  },
+  {
+    "aliases": [
+      "spades"
+    ],
+    "description": "black spade suit",
+    "tags": [],
+    "emoji": "♠"
+  },
+  {
+    "aliases": [
+      "il",
+      "flag-il"
+    ],
+    "emoji": "🇮🇱",
+    "description": "regional indicator symbol letter i + regional indicator symbol letter l",
+    "tags": [
+      "flag",
+      "israel"
+    ]
+  },
+  {
+    "aliases": [
+      "iq",
+      "flag-iq"
+    ],
+    "emoji": "🇮🇶",
+    "description": "regional indicator symbol letter i + regional indicator symbol letter q",
+    "tags": [
+      "flag",
+      "iraq"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-ir",
+      "ir"
+    ],
+    "emoji": "🇮🇷",
+    "description": "regional indicator symbol letter i + regional indicator symbol letter r",
+    "tags": [
+      "flag",
+      "iran"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-io"
+    ],
+    "description": "regional indicator symbol letters io",
+    "tags": [],
+    "emoji": "🇮🇴"
+  },
+  {
+    "aliases": [
+      "clock930"
+    ],
+    "description": "clock face nine-thirty",
+    "tags": [],
+    "emoji": "🕤"
+  },
+  {
+    "aliases": [
+      "fast_forward"
+    ],
+    "description": "black right-pointing double triangle",
+    "tags": [],
+    "emoji": "⏩"
+  },
+  {
+    "aliases": [
+      "flag-is",
+      "is"
+    ],
+    "emoji": "🇮🇸",
+    "description": "regional indicator symbol letter i + regional indicator symbol letter s",
+    "tags": [
+      "flag",
+      "iceland"
+    ]
+  },
+  {
+    "aliases": [
+      "it",
+      "flag-it"
+    ],
+    "emoji": "🇮🇹",
+    "description": "regional indicator symbol letter i + regional indicator symbol letter t",
+    "tags": [
+      "flag",
+      "italy"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-vg",
+      "vg"
+    ],
+    "emoji": "🇻🇬",
+    "description": "regional indicator symbol letter v + regional indicator symbol letter g",
+    "tags": [
+      "flag",
+      "british virgin islands"
+    ]
+  },
+  {
+    "aliases": [
+      "national_park"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "national park",
+    "tags": [],
+    "emoji": "🏞"
+  },
+  {
+    "aliases": [
+      "black_right_pointing_double_triangle_with_vertical_bar"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "black right-pointing double triangle with vertical bar",
+    "tags": [],
+    "emoji": "⏭"
+  },
+  {
+    "aliases": [
+      "hotsprings"
+    ],
+    "description": "hot springs",
+    "tags": [],
+    "emoji": "♨"
+  },
+  {
+    "aliases": [
+      "ie",
+      "flag-ie"
+    ],
+    "emoji": "🇮🇪",
+    "description": "regional indicator symbol letter i + regional indicator symbol letter e",
+    "tags": [
+      "flag",
+      "ireland"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-ic"
+    ],
+    "description": "regional indicator symbol letters ic",
+    "tags": [],
+    "emoji": "🇮🇨"
+  },
+  {
+    "aliases": [
+      "id",
+      "flag-id"
+    ],
+    "emoji": "🇮🇩",
+    "description": "regional indicator symbol letter i + regional indicator symbol letter d",
+    "tags": [
+      "flag",
+      "indonesia"
+    ]
+  },
+  {
+    "aliases": [
+      "white_medium_small_square"
+    ],
+    "description": "white medium small square",
+    "tags": [],
+    "emoji": "◽"
+  },
+  {
+    "aliases": [
+      "desert"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "desert with cactus",
+    "tags": [],
+    "emoji": "🏜"
+  },
+  {
+    "aliases": [
+      "clock530"
+    ],
+    "description": "clock face five-thirty",
+    "tags": [],
+    "emoji": "🕠"
+  },
+  {
+    "aliases": [
+      "flag-er",
+      "er"
+    ],
+    "emoji": "🇪🇷",
+    "description": "regional indicator symbol letter e + regional indicator symbol letter r",
+    "tags": [
+      "flag",
+      "eritrea"
+    ]
+  },
+  {
+    "aliases": [
+      "desert_island"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "desert island with palm tree",
+    "tags": [],
+    "emoji": "🏝"
+  },
+  {
+    "aliases": [
+      "derelict_house",
+      "abandoned_house",
+      "old_house",
+      "derelict_house_building"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "derelict house",
+    "tags": [],
+    "emoji": "🏚"
+  },
+  {
+    "aliases": [
+      "clock730"
+    ],
+    "description": "clock face seven-thirty",
+    "tags": [],
+    "emoji": "🕢"
+  },
+  {
+    "aliases": [
+      "flag-eu"
+    ],
+    "description": "regional indicator symbol letters eu",
+    "tags": [],
+    "emoji": "🇪🇺"
+  },
+  {
+    "aliases": [
+      "volleyball"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "volleyball",
+    "tags": [],
+    "emoji": "🏐"
+  },
+  {
+    "aliases": [
+      "flag-es",
+      "es"
+    ],
+    "emoji": "🇪🇸",
+    "description": "regional indicator symbol letter e + regional indicator symbol letter s",
+    "tags": [
+      "flag",
+      "spain"
+    ]
+  },
+  {
+    "aliases": [
+      "et",
+      "flag-et"
+    ],
+    "emoji": "🇪🇹",
+    "description": "regional indicator symbol letter e + regional indicator symbol letter t",
+    "tags": [
+      "flag",
+      "ethiopia"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-ea"
+    ],
+    "description": "regional indicator symbol letters ea",
+    "tags": [],
+    "emoji": "🇪🇦"
+  },
+  {
+    "aliases": [
+      "multiple_houses",
+      "house_buildings"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "house buildings",
+    "tags": [],
+    "emoji": "🏘"
+  },
+  {
+    "aliases": [
+      "heavy_minus_sign"
+    ],
+    "description": "heavy minus sign",
+    "tags": [],
+    "emoji": "➖"
+  },
+  {
+    "aliases": [
+      "flag-eg",
+      "eg"
+    ],
+    "emoji": "🇪🇬",
+    "description": "regional indicator symbol letter e + regional indicator symbol letter g",
+    "tags": [
+      "flag",
+      "egypt"
+    ]
+  },
+  {
+    "aliases": [
+      "cityscape"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "cityscape",
+    "tags": [],
+    "emoji": "🏙"
+  },
+  {
+    "aliases": [
+      "ee",
+      "flag-ee"
+    ],
+    "emoji": "🇪🇪",
+    "description": "regional indicator symbol letter e + regional indicator symbol letter e",
+    "tags": [
+      "flag",
+      "estonia"
+    ]
+  },
+  {
+    "aliases": [
+      "man-woman-girl-girl",
+      "family_man_woman_girl_girl"
+    ],
+    "description": "family (man, woman, girl, girl)",
+    "tags": [
+      "family",
+      "man",
+      "woman",
+      "girl"
+    ],
+    "emoji": "👨‍👩‍👧‍👧"
+  },
+  {
+    "aliases": [
+      "flag-ec",
+      "ec"
+    ],
+    "emoji": "🇪🇨",
+    "description": "regional indicator symbol letter e + regional indicator symbol letter c",
+    "tags": [
+      "flag",
+      "ecuador"
+    ]
+  },
+  {
+    "aliases": [
+      "airplane_arriving",
+      "airplane_arrival",
+      "landing"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "airplane arriving",
+    "tags": [],
+    "emoji": "🛬"
+  },
+  {
+    "aliases": [
+      "trophy"
+    ],
+    "description": "trophy",
+    "tags": [
+      "award",
+      "contest",
+      "winner"
+    ],
+    "emoji": "🏆"
+  },
+  {
+    "aliases": [
+      "bt",
+      "flag-bt"
+    ],
+    "emoji": "🇧🇹",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter t",
+    "tags": [
+      "flag",
+      "bhutan"
+    ]
+  },
+  {
+    "aliases": [
+      "atom_symbol",
+      "atom"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "atom symbol",
+    "tags": [],
+    "emoji": "⚛"
+  },
+  {
+    "aliases": [
+      "horse_racing"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "horse racing",
+    "tags": [],
+    "emoji": "🏇"
+  },
+  {
+    "aliases": [
+      "arrow_right_hook"
+    ],
+    "description": "rightwards arrow with hook",
+    "tags": [],
+    "emoji": "↪"
+  },
+  {
+    "aliases": [
+      "flag-ve",
+      "ve"
+    ],
+    "emoji": "🇻🇪",
+    "description": "regional indicator symbol letter v + regional indicator symbol letter e",
+    "tags": [
+      "flag",
+      "venezuela"
+    ]
+  },
+  {
+    "aliases": [
+      "golf"
+    ],
+    "description": "flag in hole",
+    "tags": [],
+    "emoji": "⛳"
+  },
+  {
+    "aliases": [
+      "white_large_square"
+    ],
+    "description": "white large square",
+    "tags": [],
+    "emoji": "⬜"
+  },
+  {
+    "aliases": [
+      "funeral",
+      "casket",
+      "coffin"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "coffin",
+    "tags": [],
+    "emoji": "⚰"
+  },
+  {
+    "aliases": [
+      "sports_medal",
+      "sports_decoration"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "sports medal",
+    "tags": [],
+    "emoji": "🏅"
+  },
+  {
+    "aliases": [
+      "arrow_heading_down"
+    ],
+    "description": "arrow pointing rightwards then curving downwards",
+    "tags": [],
+    "emoji": "⤵"
+  },
+  {
     "aliases": [
       "bow_and_arrow",
       "bow_arrow",
       "archery"
     ],
-    "tags": []
+    "supports_fitzpatrick": false,
+    "description": "bow and arrow",
+    "tags": [],
+    "emoji": "🏹"
   },
   {
-    "emoji": "⚰",
-    "description": "coffin",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "coffin",
-      "funeral",
-      "casket"
+      "woman-woman-girl",
+      "family_woman_woman_girl"
     ],
-    "tags": []
+    "description": "family (woman, woman, girl)",
+    "tags": [
+      "family",
+      "woman",
+      "girl"
+    ],
+    "emoji": "👩‍👩‍👧"
   },
   {
-    "emoji": "⚱",
-    "description": "funeral urn",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "funeral_urn"
+      "snowboarder"
     ],
-    "tags": []
+    "description": "snowboarder",
+    "tags": [],
+    "emoji": "🏂"
   },
   {
-    "emoji": "🏳",
-    "description": "waving white flag",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "waving_white_flag"
+      "scorpion"
     ],
-    "tags": []
+    "supports_fitzpatrick": false,
+    "description": "scorpion",
+    "tags": [],
+    "emoji": "🦂"
   },
   {
-    "emoji": "🏴",
-    "description": "waving black flag",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "waving_black_flag"
+      "turkey"
     ],
-    "tags": []
+    "supports_fitzpatrick": false,
+    "description": "turkey",
+    "tags": [],
+    "emoji": "🦃"
   },
   {
-    "emoji": "⚜",
-    "description": "fleur-de-lis",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "fleur_de_lis",
-      "scouts"
+      "unicorn_face"
     ],
-    "tags": []
+    "supports_fitzpatrick": false,
+    "description": "unicorn face",
+    "tags": [],
+    "emoji": "🦄"
   },
   {
-    "emoji": "⚛",
-    "description": "atom symbol",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "atom",
-      "atom_symbol"
+      "five"
     ],
-    "tags": []
+    "description": "digit five + combining enclosing keycap",
+    "tags": [],
+    "emoji": "5⃣"
   },
   {
-    "emoji": "🕉",
-    "description": "om symbol",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "om_symbol",
-      "pranava",
-      "aumkara",
-      "omkara"
+      "runner",
+      "running"
     ],
-    "tags": []
+    "supports_fitzpatrick": true,
+    "description": "runner",
+    "tags": [
+      "exercise",
+      "workout",
+      "marathon"
+    ],
+    "emoji": "🏃"
   },
   {
-    "emoji": "✡",
-    "description": "star of David",
+    "aliases": [
+      "basketball"
+    ],
+    "description": "basketball and hoop",
+    "tags": [
+      "sports"
+    ],
+    "emoji": "🏀"
+  },
+  {
+    "aliases": [
+      "cancer"
+    ],
+    "description": "cancer",
+    "tags": [],
+    "emoji": "♋"
+  },
+  {
+    "aliases": [
+      "checkered_flag"
+    ],
+    "description": "chequered flag",
+    "tags": [
+      "milestone",
+      "finish"
+    ],
+    "emoji": "🏁"
+  },
+  {
+    "aliases": [
+      "camera_flash",
+      "camera_with_flash"
+    ],
     "supports_fitzpatrick": false,
+    "description": "camera with flash",
+    "tags": [],
+    "emoji": "📸"
+  },
+  {
+    "aliases": [
+      "f1",
+      "racing_car",
+      "formula_one"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "racing car",
+    "tags": [],
+    "emoji": "🏎"
+  },
+  {
+    "aliases": [
+      "clock7"
+    ],
+    "description": "clock face seven oclock",
+    "tags": [],
+    "emoji": "🕖"
+  },
+  {
+    "aliases": [
+      "cricket_bat_and_ball",
+      "cricket"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "cricket bat and ball",
+    "tags": [],
+    "emoji": "🏏"
+  },
+  {
+    "aliases": [
+      "ng"
+    ],
+    "description": "squared ng",
+    "tags": [],
+    "emoji": "🆖"
+  },
+  {
+    "aliases": [
+      "regional_indicator_symbol_l"
+    ],
+    "emoji": "🇱",
+    "description": "regional indicator symbol letter l",
+    "tags": [
+      "letter",
+      "l"
+    ]
+  },
+  {
+    "aliases": [
+      "baby_bottle"
+    ],
+    "description": "baby bottle",
+    "tags": [
+      "milk"
+    ],
+    "emoji": "🍼"
+  },
+  {
+    "aliases": [
+      "racing_motorcycle",
+      "motorcycle",
+      "motorbike"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "racing motorcycle",
+    "tags": [],
+    "emoji": "🏍"
+  },
+  {
+    "aliases": [
+      "aries"
+    ],
+    "description": "aries",
+    "tags": [],
+    "emoji": "♈"
+  },
+  {
+    "aliases": [
+      "stadium"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "stadium",
+    "tags": [],
+    "emoji": "🏟"
+  },
+  {
+    "aliases": [
+      "vc",
+      "flag-vc"
+    ],
+    "emoji": "🇻🇨",
+    "description": "regional indicator symbol letter v + regional indicator symbol letter c",
+    "tags": [
+      "flag",
+      "st vincent grenadines"
+    ]
+  },
+  {
+    "aliases": [
+      "swimmer"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "swimmer",
+    "tags": [],
+    "emoji": "🏊"
+  },
+  {
+    "aliases": [
+      "clock3"
+    ],
+    "description": "clock face three oclock",
+    "tags": [],
+    "emoji": "🕒"
+  },
+  {
+    "aliases": [
+      "man-man-girl-girl",
+      "family_man_man_girl_girl"
+    ],
+    "description": "family (man, man, girl, girl)",
+    "tags": [
+      "family",
+      "man",
+      "girl"
+    ],
+    "emoji": "👨‍👨‍👧‍👧"
+  },
+  {
+    "aliases": [
+      "weight_lifter"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "weight lifter",
+    "tags": [],
+    "emoji": "🏋"
+  },
+  {
+    "aliases": [
+      "mountain"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "mountain",
+    "tags": [],
+    "emoji": "⛰"
+  },
+  {
+    "aliases": [
+      "family_man_man_girl_boy",
+      "man-man-girl-boy"
+    ],
+    "description": "family (man, man, girl, boy)",
+    "tags": [
+      "family",
+      "man",
+      "girl",
+      "boy"
+    ],
+    "emoji": "👨‍👨‍👧‍👦"
+  },
+  {
+    "aliases": [
+      "football"
+    ],
+    "description": "american football",
+    "tags": [
+      "sports"
+    ],
+    "emoji": "🏈"
+  },
+  {
+    "aliases": [
+      "clock130"
+    ],
+    "description": "clock face one-thirty",
+    "tags": [],
+    "emoji": "🕜"
+  },
+  {
+    "aliases": [
+      "regional_indicator_symbol_y"
+    ],
+    "emoji": "🇾",
+    "description": "regional indicator symbol letter y",
+    "tags": [
+      "letter",
+      "y"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-nf"
+    ],
+    "description": "regional indicator symbol letters nf",
+    "tags": [],
+    "emoji": "🇳🇫"
+  },
+  {
+    "aliases": [
+      "recycle"
+    ],
+    "description": "black universal recycling symbol",
+    "tags": [
+      "environment",
+      "green"
+    ],
+    "emoji": "♻"
+  },
+  {
+    "aliases": [
+      "rugby_football"
+    ],
+    "description": "rugby football",
+    "tags": [],
+    "emoji": "🏉"
+  },
+  {
+    "aliases": [
+      "flag-pt",
+      "pt"
+    ],
+    "emoji": "🇵🇹",
+    "description": "regional indicator symbol letter p + regional indicator symbol letter t",
+    "tags": [
+      "flag",
+      "portugal"
+    ]
+  },
+  {
+    "aliases": [
+      "star_crescent",
+      "star_and_crescent"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "star and crescent",
+    "tags": [],
+    "emoji": "☪"
+  },
+  {
+    "aliases": [
+      "ps",
+      "flag-ps"
+    ],
+    "emoji": "🇵🇸",
+    "description": "regional indicator symbol letter p + regional indicator symbol letter s",
+    "tags": [
+      "flag",
+      "palestine"
+    ]
+  },
+  {
+    "aliases": [
+      "qa",
+      "flag-qa"
+    ],
+    "emoji": "🇶🇦",
+    "description": "regional indicator symbol letter q + regional indicator symbol letter a",
+    "tags": [
+      "flag",
+      "qatar"
+    ]
+  },
+  {
+    "aliases": [
+      "snowman",
+      "snowman_with_snow",
+      "snowing_snowman"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "snowman with snow",
+    "tags": [],
+    "emoji": "☃"
+  },
+  {
+    "aliases": [
+      "flag-ta"
+    ],
+    "description": "regional indicator symbol letters ta",
+    "tags": [],
+    "emoji": "🇹🇦"
+  },
+  {
+    "aliases": [
+      "secret"
+    ],
+    "description": "circled ideograph secret",
+    "tags": [],
+    "emoji": "㊙"
+  },
+  {
+    "aliases": [
+      "baggage_claim"
+    ],
+    "description": "baggage claim",
+    "tags": [
+      "airport"
+    ],
+    "emoji": "🛄"
+  },
+  {
+    "aliases": [
+      "clock11"
+    ],
+    "description": "clock face eleven oclock",
+    "tags": [],
+    "emoji": "🕚"
+  },
+  {
+    "aliases": [
+      "pw",
+      "flag-pw"
+    ],
+    "emoji": "🇵🇼",
+    "description": "regional indicator symbol letter p + regional indicator symbol letter w",
+    "tags": [
+      "flag",
+      "palau"
+    ]
+  },
+  {
+    "aliases": [
+      "zap"
+    ],
+    "description": "high voltage sign",
+    "tags": [
+      "lightning",
+      "thunder"
+    ],
+    "emoji": "⚡"
+  },
+  {
+    "aliases": [
+      "flag-mg",
+      "mg"
+    ],
+    "emoji": "🇲🇬",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter g",
+    "tags": [
+      "flag",
+      "madagascar"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-mh"
+    ],
+    "description": "regional indicator symbol letters mh",
+    "tags": [],
+    "emoji": "🇲🇭"
+  },
+  {
+    "aliases": [
+      "me",
+      "flag-me"
+    ],
+    "emoji": "🇲🇪",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter e",
+    "tags": [
+      "flag",
+      "montenegro"
+    ]
+  },
+  {
+    "aliases": [
+      "passenger_ship"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "passenger ship",
+    "tags": [],
+    "emoji": "🛳"
+  },
+  {
+    "aliases": [
+      "flag-mc"
+    ],
+    "description": "regional indicator symbol letters mc",
+    "tags": [],
+    "emoji": "🇲🇨"
+  },
+  {
+    "aliases": [
+      "md",
+      "flag-md"
+    ],
+    "emoji": "🇲🇩",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter d",
+    "tags": [
+      "flag",
+      "moldova"
+    ]
+  },
+  {
+    "aliases": [
+      "ma",
+      "flag-ma"
+    ],
+    "emoji": "🇲🇦",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter a",
+    "tags": [
+      "flag",
+      "morocco"
+    ]
+  },
+  {
+    "aliases": [
+      "keyboard"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "keyboard",
+    "tags": [],
+    "emoji": "⌨"
+  },
+  {
+    "aliases": [
+      "flag-py",
+      "py"
+    ],
+    "emoji": "🇵🇾",
+    "description": "regional indicator symbol letter p + regional indicator symbol letter y",
+    "tags": [
+      "flag",
+      "paraguay"
+    ]
+  },
+  {
+    "aliases": [
+      "my",
+      "flag-my"
+    ],
+    "emoji": "🇲🇾",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter y",
+    "tags": [
+      "flag",
+      "malaysia"
+    ]
+  },
+  {
+    "aliases": [
+      "envelope",
+      "email"
+    ],
+    "description": "envelope",
+    "tags": [
+      "letter"
+    ],
+    "emoji": "✉"
+  },
+  {
+    "aliases": [
+      "flag-mw",
+      "mw"
+    ],
+    "emoji": "🇲🇼",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter w",
+    "tags": [
+      "flag",
+      "malawi"
+    ]
+  },
+  {
+    "aliases": [
+      "mx",
+      "flag-mx"
+    ],
+    "emoji": "🇲🇽",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter x",
+    "tags": [
+      "flag",
+      "mexico"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-mu"
+    ],
+    "description": "regional indicator symbol letters mu",
+    "tags": [],
+    "emoji": "🇲🇺"
+  },
+  {
+    "aliases": [
+      "arrow_heading_up"
+    ],
+    "description": "arrow pointing rightwards then curving upwards",
+    "tags": [],
+    "emoji": "⤴"
+  },
+  {
+    "aliases": [
+      "flag-ms",
+      "ms"
+    ],
+    "emoji": "🇲🇸",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter s",
+    "tags": [
+      "flag",
+      "montserrat"
+    ]
+  },
+  {
+    "aliases": [
+      "mt",
+      "flag-mt"
+    ],
+    "emoji": "🇲🇹",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter t",
+    "tags": [
+      "flag",
+      "malta"
+    ]
+  },
+  {
+    "aliases": [
+      "mq",
+      "flag-mq"
+    ],
+    "emoji": "🇲🇶",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter q",
+    "tags": [
+      "flag",
+      "martinique"
+    ]
+  },
+  {
+    "aliases": [
+      "bw",
+      "flag-bw"
+    ],
+    "emoji": "🇧🇼",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter w",
+    "tags": [
+      "flag",
+      "botswana"
+    ]
+  },
+  {
+    "aliases": [
+      "underage"
+    ],
+    "description": "no one under eighteen symbol",
+    "tags": [],
+    "emoji": "🔞"
+  },
+  {
+    "aliases": [
+      "mp",
+      "flag-mp"
+    ],
+    "emoji": "🇲🇵",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter p",
+    "tags": [
+      "flag",
+      "northern mariana islands"
+    ]
+  },
+  {
+    "aliases": [
+      "mm",
+      "flag-mm"
+    ],
+    "emoji": "🇲🇲",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter m",
+    "tags": [
+      "flag",
+      "myanmar"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-mn",
+      "mn"
+    ],
+    "emoji": "🇲🇳",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter n",
+    "tags": [
+      "flag",
+      "mongolia"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-mk",
+      "mk"
+    ],
+    "emoji": "🇲🇰",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter k",
+    "tags": [
+      "flag",
+      "macedonia"
+    ]
+  },
+  {
+    "aliases": [
+      "eight_pointed_black_star"
+    ],
+    "description": "eight pointed black star",
+    "tags": [],
+    "emoji": "✴"
+  },
+  {
+    "aliases": [
+      "diamond_shape_with_a_dot_inside"
+    ],
+    "description": "diamond shape with a dot inside",
+    "tags": [],
+    "emoji": "💠"
+  },
+  {
+    "aliases": [
+      "couple_with_heart_woman_woman"
+    ],
+    "description": "couple with heart (woman, woman)",
+    "tags": [
+      "couple",
+      "heart",
+      "woman"
+    ],
+    "emoji": "👩‍❤‍👩"
+  },
+  {
+    "aliases": [
+      "ye",
+      "flag-ye"
+    ],
+    "emoji": "🇾🇪",
+    "description": "regional indicator symbol letter y + regional indicator symbol letter e",
+    "tags": [
+      "flag",
+      "yemen"
+    ]
+  },
+  {
+    "aliases": [
+      "ice_skating",
+      "ice_skate"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "single ice skate",
+    "tags": [],
+    "emoji": "⛸"
+  },
+  {
+    "aliases": [
+      "family_woman_woman_boy",
+      "woman-woman-boy"
+    ],
+    "description": "family (woman, woman, boy)",
+    "tags": [
+      "family",
+      "woman",
+      "boy"
+    ],
+    "emoji": "👩‍👩‍👦"
+  },
+  {
+    "aliases": [
+      "helmet_with_white_cross",
+      "helmet_white_cross"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "helmet with white crosse",
+    "tags": [],
+    "emoji": "⛑"
+  },
+  {
+    "aliases": [
+      "pr",
+      "flag-pr"
+    ],
+    "emoji": "🇵🇷",
+    "description": "regional indicator symbol letter p + regional indicator symbol letter r",
+    "tags": [
+      "flag",
+      "puerto rico"
+    ]
+  },
+  {
+    "aliases": [
+      "bn",
+      "flag-bn"
+    ],
+    "emoji": "🇧🇳",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter n",
+    "tags": [
+      "flag",
+      "brunei darussalam"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-yt"
+    ],
+    "description": "regional indicator symbol letters yt",
+    "tags": [],
+    "emoji": "🇾🇹"
+  },
+  {
+    "aliases": [
+      "classical_building"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "classical building",
+    "tags": [],
+    "emoji": "🏛"
+  },
+  {
+    "aliases": [
+      "ua",
+      "flag-ua"
+    ],
+    "emoji": "🇺🇦",
+    "description": "regional indicator symbol letter u + regional indicator symbol letter a",
+    "tags": [
+      "flag",
+      "ukraine"
+    ]
+  },
+  {
+    "aliases": [
+      "gt",
+      "flag-gt"
+    ],
+    "emoji": "🇬🇹",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter t",
+    "tags": [
+      "flag",
+      "guatemala"
+    ]
+  },
+  {
+    "aliases": [
+      "gu",
+      "flag-gu"
+    ],
+    "emoji": "🇬🇺",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter u",
+    "tags": [
+      "flag",
+      "guam"
+    ]
+  },
+  {
+    "aliases": [
+      "candelabrum",
+      "chanukiah",
+      "menorah",
+      "menorah_with_nine_branches"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "menorah with nine branches",
+    "tags": [],
+    "emoji": "🕎"
+  },
+  {
+    "aliases": [
+      "gw",
+      "flag-gw"
+    ],
+    "emoji": "🇬🇼",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter w",
+    "tags": [
+      "flag",
+      "guinea-bissau"
+    ]
+  },
+  {
+    "aliases": [
+      "couple_with_heart_man_man"
+    ],
+    "description": "couple with heart (man, man)",
+    "tags": [
+      "couple",
+      "heart",
+      "man"
+    ],
+    "emoji": "👨‍❤‍👨"
+  },
+  {
+    "aliases": [
+      "flag-gy",
+      "gy"
+    ],
+    "emoji": "🇬🇾",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter y",
+    "tags": [
+      "flag",
+      "guyana"
+    ]
+  },
+  {
+    "aliases": [
+      "diamonds"
+    ],
+    "description": "black diamond suit",
+    "tags": [],
+    "emoji": "♦"
+  },
+  {
+    "aliases": [
+      "place_of_worship",
+      "religious_building",
+      "worship_place",
+      "worship_building",
+      "religious_place"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "place of worship",
+    "tags": [],
+    "emoji": "🛐"
+  },
+  {
+    "aliases": [
+      "flag-gl"
+    ],
+    "description": "regional indicator symbol letters gl",
+    "tags": [],
+    "emoji": "🇬🇱"
+  },
+  {
+    "aliases": [
+      "gm",
+      "flag-gm"
+    ],
+    "emoji": "🇬🇲",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter m",
+    "tags": [
+      "flag",
+      "gambia"
+    ]
+  },
+  {
+    "aliases": [
+      "gn",
+      "flag-gn"
+    ],
+    "emoji": "🇬🇳",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter n",
+    "tags": [
+      "flag",
+      "guinea"
+    ]
+  },
+  {
+    "aliases": [
+      "fi",
+      "flag-fi"
+    ],
+    "emoji": "🇫🇮",
+    "description": "regional indicator symbol letter f + regional indicator symbol letter i",
+    "tags": [
+      "flag",
+      "finland"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-gp",
+      "gp"
+    ],
+    "emoji": "🇬🇵",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter p",
+    "tags": [
+      "flag",
+      "guadeloupe"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-gq",
+      "gq"
+    ],
+    "emoji": "🇬🇶",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter q",
+    "tags": [
+      "flag",
+      "equatorial guinea"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-gr",
+      "gr"
+    ],
+    "emoji": "🇬🇷",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter r",
+    "tags": [
+      "flag",
+      "greece"
+    ]
+  },
+  {
+    "aliases": [
+      "planted_umbrella",
+      "umbrella_on_ground"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "umbrella planted on the ground",
+    "tags": [],
+    "emoji": "⛱"
+  },
+  {
+    "aliases": [
+      "gd",
+      "flag-gd"
+    ],
+    "emoji": "🇬🇩",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter d",
+    "tags": [
+      "flag",
+      "grenada"
+    ]
+  },
+  {
+    "aliases": [
+      "hourglass_flowing_sand"
+    ],
+    "description": "hourglass with flowing sand",
+    "tags": [
+      "time"
+    ],
+    "emoji": "⏳"
+  },
+  {
+    "aliases": [
+      "bathtub"
+    ],
+    "description": "bathtub",
+    "tags": [],
+    "emoji": "🛁"
+  },
+  {
+    "aliases": [
+      "flag-gg"
+    ],
+    "description": "regional indicator symbol letters gg",
+    "tags": [],
+    "emoji": "🇬🇬"
+  },
+  {
+    "aliases": [
+      "bm",
+      "flag-bm"
+    ],
+    "emoji": "🇧🇲",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter m",
+    "tags": [
+      "flag",
+      "bermuda"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-gi",
+      "gi"
+    ],
+    "emoji": "🇬🇮",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter i",
+    "tags": [
+      "flag",
+      "gibraltar"
+    ]
+  },
+  {
+    "aliases": [
+      "uy",
+      "flag-uy"
+    ],
+    "emoji": "🇺🇾",
+    "description": "regional indicator symbol letter u + regional indicator symbol letter y",
+    "tags": [
+      "flag",
+      "uruguay"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-so",
+      "so"
+    ],
+    "emoji": "🇸🇴",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter o",
+    "tags": [
+      "flag",
+      "somalia"
+    ]
+  },
+  {
+    "aliases": [
+      "dove_of_peace",
+      "dove",
+      "dove_peace"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "dove of peace, carrying an olive branch",
+    "tags": [],
+    "emoji": "🕊"
+  },
+  {
+    "aliases": [
+      "four"
+    ],
+    "description": "digit four + combining enclosing keycap",
+    "tags": [],
+    "emoji": "4⃣"
+  },
+  {
+    "aliases": [
+      "flag-ga",
+      "ga"
+    ],
+    "emoji": "🇬🇦",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter a",
+    "tags": [
+      "flag",
+      "gabon"
+    ]
+  },
+  {
+    "aliases": [
+      "dk",
+      "flag-dk"
+    ],
+    "emoji": "🇩🇰",
+    "description": "regional indicator symbol letter d + regional indicator symbol letter k",
+    "tags": [
+      "flag",
+      "denmark"
+    ]
+  },
+  {
+    "aliases": [
+      "cloud"
+    ],
+    "description": "cloud",
+    "tags": [],
+    "emoji": "☁"
+  },
+  {
+    "aliases": [
+      "flag-cx"
+    ],
+    "description": "regional indicator symbol letters cx",
+    "tags": [],
+    "emoji": "🇨🇽"
+  },
+  {
+    "aliases": [
+      "white_check_mark"
+    ],
+    "description": "white heavy check mark",
+    "tags": [],
+    "emoji": "✅"
+  },
+  {
+    "aliases": [
+      "cz",
+      "flag-cz"
+    ],
+    "emoji": "🇨🇿",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter z",
+    "tags": [
+      "flag",
+      "czech republic"
+    ]
+  },
+  {
+    "aliases": [
+      "motorway",
+      "freeway",
+      "road",
+      "highway",
+      "interstate"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "motorway",
+    "tags": [],
+    "emoji": "🛣"
+  },
+  {
+    "aliases": [
+      "flag-cu",
+      "cu"
+    ],
+    "emoji": "🇨🇺",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter u",
+    "tags": [
+      "flag",
+      "cuba"
+    ]
+  },
+  {
+    "aliases": [
+      "red_circle"
+    ],
+    "description": "large red circle",
+    "tags": [],
+    "emoji": "🔴"
+  },
+  {
+    "aliases": [
+      "flag-co",
+      "co"
+    ],
+    "emoji": "🇨🇴",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter o",
+    "tags": [
+      "flag",
+      "colombia"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-cp"
+    ],
+    "description": "regional indicator symbol letters cp",
+    "tags": [],
+    "emoji": "🇨🇵"
+  },
+  {
+    "aliases": [
+      "hand",
+      "raised_hand"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "raised hand",
+    "tags": [
+      "highfive",
+      "stop"
+    ],
+    "emoji": "✋"
+  },
+  {
+    "aliases": [
+      "cr",
+      "flag-cr"
+    ],
+    "emoji": "🇨🇷",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter r",
+    "tags": [
+      "flag",
+      "costa rica"
+    ]
+  },
+  {
+    "aliases": [
+      "ck",
+      "flag-ck"
+    ],
+    "emoji": "🇨🇰",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter k",
+    "tags": [
+      "flag",
+      "cook islands"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-cl",
+      "cl"
+    ],
+    "emoji": "🇨🇱",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter l",
+    "tags": [
+      "flag",
+      "chile"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-cm",
+      "cm"
+    ],
+    "emoji": "🇨🇲",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter m",
+    "tags": [
+      "flag",
+      "cameroon"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-cn",
+      "cn"
+    ],
+    "emoji": "🇨🇳",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter n",
+    "tags": [
+      "flag",
+      "china"
+    ]
+  },
+  {
+    "aliases": [
+      "space_invader"
+    ],
+    "description": "alien monster",
+    "tags": [
+      "game",
+      "retro"
+    ],
+    "emoji": "👾"
+  },
+  {
+    "aliases": [
+      "ch",
+      "flag-ch"
+    ],
+    "emoji": "🇨🇭",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter h",
+    "tags": [
+      "flag",
+      "switzerland"
+    ]
+  },
+  {
+    "aliases": [
+      "ci",
+      "flag-ci"
+    ],
+    "emoji": "🇨🇮",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter i",
+    "tags": [
+      "flag",
+      "ivory coast"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-bl"
+    ],
+    "description": "regional indicator symbol letters bl",
+    "tags": [],
+    "emoji": "🇧🇱"
+  },
+  {
+    "aliases": [
+      "flag-cc"
+    ],
+    "description": "regional indicator symbol letters cc",
+    "tags": [],
+    "emoji": "🇨🇨"
+  },
+  {
+    "aliases": [
+      "left_right_arrow"
+    ],
+    "description": "left right arrow",
+    "tags": [],
+    "emoji": "↔"
+  },
+  {
+    "aliases": [
+      "flag-cf",
+      "cf"
+    ],
+    "emoji": "🇨🇫",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter f",
+    "tags": [
+      "flag",
+      "central african republic"
+    ]
+  },
+  {
+    "aliases": [
+      "family_man_man_boy_boy",
+      "man-man-boy-boy"
+    ],
+    "description": "family (man, man, boy, boy)",
+    "tags": [
+      "family",
+      "man",
+      "boy"
+    ],
+    "emoji": "👨‍👨‍👦‍👦"
+  },
+  {
+    "aliases": [
+      "trident"
+    ],
+    "description": "trident emblem",
+    "tags": [],
+    "emoji": "🔱"
+  },
+  {
+    "aliases": [
+      "ca",
+      "flag-ca"
+    ],
+    "emoji": "🇨🇦",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter a",
+    "tags": [
+      "flag",
+      "canada"
+    ]
+  },
+  {
+    "aliases": [
+      "beginner"
+    ],
+    "description": "japanese symbol for beginner",
+    "tags": [],
+    "emoji": "🔰"
+  },
+  {
+    "aliases": [
+      "au",
+      "flag-au"
+    ],
+    "emoji": "🇦🇺",
+    "description": "regional indicator symbol letter a + regional indicator symbol letter u",
+    "tags": [
+      "flag",
+      "australia"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-as",
+      "as"
+    ],
+    "emoji": "🇦🇸",
+    "description": "regional indicator symbol letter a + regional indicator symbol letter s",
+    "tags": [
+      "flag",
+      "american samoa"
+    ]
+  },
+  {
+    "aliases": [
+      "heavy_check_mark"
+    ],
+    "description": "heavy check mark",
+    "tags": [],
+    "emoji": "✔"
+  },
+  {
+    "aliases": [
+      "flag-az",
+      "az"
+    ],
+    "emoji": "🇦🇿",
+    "description": "regional indicator symbol letter a + regional indicator symbol letter z",
+    "tags": [
+      "flag",
+      "azerbaijan"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-aw",
+      "aw"
+    ],
+    "emoji": "🇦🇼",
+    "description": "regional indicator symbol letter a + regional indicator symbol letter w",
+    "tags": [
+      "flag",
+      "aruba"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-ax"
+    ],
+    "description": "regional indicator symbol letters ax",
+    "tags": [],
+    "emoji": "🇦🇽"
+  },
+  {
+    "aliases": [
+      "am",
+      "flag-am"
+    ],
+    "emoji": "🇦🇲",
+    "description": "regional indicator symbol letter a + regional indicator symbol letter m",
+    "tags": [
+      "flag",
+      "armenia"
+    ]
+  },
+  {
+    "aliases": [
+      "tornado",
+      "tornado_cloud",
+      "cloud_tornado"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "cloud with tornado",
+    "tags": [],
+    "emoji": "🌪"
+  },
+  {
+    "aliases": [
+      "black_square_button"
+    ],
+    "description": "black square button",
+    "tags": [],
+    "emoji": "🔲"
+  },
+  {
+    "aliases": [
+      "flag-aq"
+    ],
+    "description": "regional indicator symbol letters aq",
+    "tags": [],
+    "emoji": "🇦🇶"
+  },
+  {
+    "aliases": [
+      "flag-ar",
+      "ar"
+    ],
+    "emoji": "🇦🇷",
+    "description": "regional indicator symbol letter a + regional indicator symbol letter r",
+    "tags": [
+      "flag",
+      "argentina"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-ao",
+      "ao"
+    ],
+    "emoji": "🇦🇴",
+    "description": "regional indicator symbol letter a + regional indicator symbol letter o",
+    "tags": [
+      "flag",
+      "angola"
+    ]
+  },
+  {
+    "aliases": [
+      "customs"
+    ],
+    "description": "customs",
+    "tags": [],
+    "emoji": "🛃"
+  },
+  {
+    "aliases": [
+      "ae",
+      "flag-ae"
+    ],
+    "emoji": "🇦🇪",
+    "description": "regional indicator symbol letter a + regional indicator symbol letter e",
+    "tags": [
+      "flag",
+      "united arab emirates"
+    ]
+  },
+  {
+    "aliases": [
+      "curly_loop"
+    ],
+    "description": "curly loop",
+    "tags": [],
+    "emoji": "➰"
+  },
+  {
+    "aliases": [
+      "arrow_upper_right"
+    ],
+    "description": "north east arrow",
+    "tags": [],
+    "emoji": "↗"
+  },
+  {
+    "aliases": [
+      "ad",
+      "flag-ad"
+    ],
+    "emoji": "🇦🇩",
+    "description": "regional indicator symbol letter a + regional indicator symbol letter d",
+    "tags": [
+      "flag",
+      "andorra"
+    ]
+  },
+  {
+    "aliases": [
+      "ai",
+      "flag-ai"
+    ],
+    "emoji": "🇦🇮",
+    "description": "regional indicator symbol letter a + regional indicator symbol letter i",
+    "tags": [
+      "flag",
+      "anguilla"
+    ]
+  },
+  {
+    "aliases": [
+      "cloud_snow",
+      "snow_cloud"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "cloud with snow",
+    "tags": [],
+    "emoji": "🌨"
+  },
+  {
+    "aliases": [
+      "flag-ag",
+      "ag"
+    ],
+    "emoji": "🇦🇬",
+    "description": "regional indicator symbol letter a + regional indicator symbol letter g",
+    "tags": [
+      "flag",
+      "antigua and barbuda"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-lc"
+    ],
+    "description": "regional indicator symbol letters lc",
+    "tags": [],
+    "emoji": "🇱🇨"
+  },
+  {
+    "aliases": [
+      "lightning_cloud",
+      "lightning",
+      "cloud_lightning"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "cloud with lightning",
+    "tags": [],
+    "emoji": "🌩"
+  },
+  {
     "aliases": [
       "star_of_david"
     ],
-    "tags": []
+    "supports_fitzpatrick": false,
+    "description": "star of David",
+    "tags": [],
+    "emoji": "✡"
   },
   {
-    "emoji": "☸",
-    "description": "wheel of Dharma",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "wheel_of_dharma"
+      "m"
     ],
-    "tags": []
+    "description": "circled latin capital letter m",
+    "tags": [],
+    "emoji": "Ⓜ"
   },
   {
-    "emoji": "☯",
-    "description": "yin yang",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "yin_yang"
+      "trolleybus"
     ],
-    "tags": []
+    "description": "trolleybus",
+    "tags": [],
+    "emoji": "🚎"
   },
   {
-    "emoji": "✝",
-    "description": "latin cross",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "latin_cross",
-      "christian_cross"
+      "tg",
+      "flag-tg"
     ],
-    "tags": []
+    "emoji": "🇹🇬",
+    "description": "regional indicator symbol letter t + regional indicator symbol letter g",
+    "tags": [
+      "flag",
+      "togo"
+    ]
   },
   {
-    "emoji": "☦",
-    "description": "orthodox cross",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "orthodox_cross"
+      "passport_control"
     ],
-    "tags": []
+    "description": "passport control",
+    "tags": [],
+    "emoji": "🛂"
   },
   {
-    "emoji": "⛩",
-    "description": "shinto shrine",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "shinto_shrine",
-      "kami_no_michi"
+      "small_orange_diamond"
     ],
-    "tags": []
+    "description": "small orange diamond",
+    "tags": [],
+    "emoji": "🔸"
   },
   {
-    "emoji": "☪",
-    "description": "star and crescent",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "star_and_crescent",
-      "star_crescent"
+      "capricorn"
     ],
-    "tags": []
+    "description": "capricorn",
+    "tags": [],
+    "emoji": "♑"
   },
   {
-    "emoji": "☮",
-    "description": "peace symbol",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "peace_symbol",
-      "peace_sign"
+      "night_with_stars"
     ],
-    "tags": []
+    "description": "night with stars",
+    "tags": [],
+    "emoji": "🌃"
   },
   {
-    "emoji": "☢",
-    "description": "radioactive symbol",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "radioactive",
-      "radioactive_symbol",
-      "radioactive_sign"
+      "flag-ly",
+      "ly"
     ],
-    "tags": []
+    "emoji": "🇱🇾",
+    "description": "regional indicator symbol letter l + regional indicator symbol letter y",
+    "tags": [
+      "flag",
+      "libya"
+    ]
   },
   {
-    "emoji": "☣",
-    "description": "biohazard symbol",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "biohazard",
-      "biohazard_symbol",
-      "biohazard_sign"
+      "bed",
+      "bedroom"
     ],
-    "tags": []
+    "supports_fitzpatrick": false,
+    "description": "bed or bedroom",
+    "tags": [],
+    "emoji": "🛏"
   },
   {
-    "emoji": "🗨",
-    "description": "left speech bubble",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "left_speech_bubble"
+      "field_hockey",
+      "field_hockey_stick_and_ball"
     ],
-    "tags": []
+    "supports_fitzpatrick": false,
+    "description": "field hockey stick and ball",
+    "tags": [],
+    "emoji": "🏑"
   },
   {
-    "emoji": "👁‍🗨",
-    "description": "eye in speech bubble",
-    "supports_fitzpatrick": false,
     "aliases": [
-      "eye_in_speech_bubble",
-      "i_am_a_witness"
+      "flag-lt",
+      "lt"
     ],
-    "tags": []
+    "emoji": "🇱🇹",
+    "description": "regional indicator symbol letter l + regional indicator symbol letter t",
+    "tags": [
+      "flag",
+      "lithuania"
+    ]
+  },
+  {
+    "aliases": [
+      "control_knobs"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "control knobs",
+    "tags": [],
+    "emoji": "🎛"
+  },
+  {
+    "aliases": [
+      "ls",
+      "flag-ls"
+    ],
+    "emoji": "🇱🇸",
+    "description": "regional indicator symbol letter l + regional indicator symbol letter s",
+    "tags": [
+      "flag",
+      "lesotho"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-gb",
+      "gb",
+      "uk"
+    ],
+    "emoji": "🇬🇧",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter b",
+    "tags": [
+      "flag",
+      "united kingdom"
+    ]
+  },
+  {
+    "aliases": [
+      "lv",
+      "flag-lv"
+    ],
+    "emoji": "🇱🇻",
+    "description": "regional indicator symbol letter l + regional indicator symbol letter v",
+    "tags": [
+      "flag",
+      "latvia"
+    ]
+  },
+  {
+    "aliases": [
+      "abc"
+    ],
+    "description": "input symbol for latin letters",
+    "tags": [
+      "alphabet"
+    ],
+    "emoji": "🔤"
+  },
+  {
+    "aliases": [
+      "regional_indicator_symbol_a"
+    ],
+    "emoji": "🇦",
+    "description": "regional indicator symbol letter a",
+    "tags": [
+      "letter",
+      "a"
+    ]
+  },
+  {
+    "aliases": [
+      "tj",
+      "flag-tj"
+    ],
+    "emoji": "🇹🇯",
+    "description": "regional indicator symbol letter t + regional indicator symbol letter j",
+    "tags": [
+      "flag",
+      "tajikistan"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-cg",
+      "cg"
+    ],
+    "emoji": "🇨🇬",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter g",
+    "tags": [
+      "flag",
+      "republic of the congo"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-lu",
+      "lu"
+    ],
+    "emoji": "🇱🇺",
+    "description": "regional indicator symbol letter l + regional indicator symbol letter u",
+    "tags": [
+      "flag",
+      "luxembourg"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-ug",
+      "ug"
+    ],
+    "emoji": "🇺🇬",
+    "description": "regional indicator symbol letter u + regional indicator symbol letter g",
+    "tags": [
+      "flag",
+      "uganda"
+    ]
+  },
+  {
+    "aliases": [
+      "flag-bq"
+    ],
+    "description": "regional indicator symbol letters bq",
+    "tags": [],
+    "emoji": "🇧🇶"
+  },
+  {
+    "aliases": [
+      "golfer",
+      "golf_club"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "golfer swinging a golf club",
+    "tags": [],
+    "emoji": "🏌"
+  },
+  {
+    "aliases": [
+      "id"
+    ],
+    "description": "squared id",
+    "tags": [],
+    "emoji": "🆔"
+  },
+  {
+    "aliases": [
+      "surfer"
+    ],
+    "supports_fitzpatrick": true,
+    "description": "surfer",
+    "tags": [],
+    "emoji": "🏄"
+  },
+  {
+    "aliases": [
+      "double_vertical_bar"
+    ],
+    "supports_fitzpatrick": false,
+    "description": "double vertical bar",
+    "tags": [],
+    "emoji": "⏸"
+  },
+  {
+    "aliases": [
+      "black_medium_square"
+    ],
+    "description": "black medium square",
+    "tags": [],
+    "emoji": "◼"
+  },
+  {
+    "aliases": [
+      "capital_abcd"
+    ],
+    "description": "input symbol for latin capital letters",
+    "tags": [
+      "letters"
+    ],
+    "emoji": "🔠"
   }
 ]

--- a/src/test/java/com/vdurmont/emoji/EmojiParserTest.java
+++ b/src/test/java/com/vdurmont/emoji/EmojiParserTest.java
@@ -422,7 +422,7 @@ public class EmojiParserTest {
 
   @Test
   public void test_with_a_new_flag() {
-    String input = "Cuba has a new flag! :cu:";
+    String input = "Cuba has a new flag! :flag-cu:";
     String expected = "Cuba has a new flag! \uD83C\uDDE8\uD83C\uDDFA";
 
     assertEquals(expected, EmojiParser.parseToUnicode(input));


### PR DESCRIPTION
Products like Slack use https://github.com/iamcal/emoji-data as the standard for alias-emoji pairs. This adds support for missing aliases to the emojis.json file.