### PR TITLE
Add API to force rendering emojis as text

### DIFF
--- a/src/main/java/com/vdurmont/emoji/Emoji.java
+++ b/src/main/java/com/vdurmont/emoji/Emoji.java
@@ -172,6 +172,23 @@ public class Emoji {
     return this.htmlHex;
   }
 
+  /**
+   * Returns the unicode representation of the emoji that may force the client to render this
+   * emoji as text.
+   *
+   * See http://mts.io/2015/04/21/unicode-symbol-render-text-emoji/ for details
+   *
+   * VARIATION SELECTOR-15 (U+FE0E) is a Nonspacing Mark that has the following property:
+   * This codepoint may change the appearance of the preceding character. If that is a symbol,
+   * dingbat or emoji, U+FE0E forces it to be rendered in a textual fashion as compared
+   * to a colorful image.
+   *
+   * @return unicode representation with appended U+FE0E
+   */
+  public String getAsText() {
+    return this.getUnicode() + "\uFE0E";
+  }
+
   @Override
   public boolean equals(Object other) {
     return !(other == null || !(other instanceof Emoji)) &&

--- a/src/main/java/com/vdurmont/emoji/EmojiParser.java
+++ b/src/main/java/com/vdurmont/emoji/EmojiParser.java
@@ -99,6 +99,24 @@ public class EmojiParser {
    * their unicode.
    */
   public static String parseToUnicode(String input) {
+      return parseToUnicode(input, false);
+  }
+
+  /**
+   * Replaces the emoji's aliases (between 2 ':') occurrences and the html
+   * representations by their unicode.<br>
+   * Examples:<br>
+   * <code>:smile:</code> will be replaced by <code>😄</code><br>
+   * <code>&amp;#128516;</code> will be replaced by <code>😄</code><br>
+   * <code>:boy|type_6:</code> will be replaced by <code>👦🏿</code>
+   *
+   * @param input the string to parse
+   * @param parseAsText force the client to render emojis as text
+   *
+   * @return the string with the aliases and html representations replaced by
+   * their unicode.
+   */
+  public static String parseToUnicode(String input, Boolean parseAsText) {
     // Get all the potential aliases
     List<AliasCandidate> candidates = getAliasCandidates(input);
 
@@ -115,6 +133,9 @@ public class EmojiParser {
           if (candidate.fitzpatrick != null) {
             replacement += candidate.fitzpatrick.unicode;
           }
+          if(parseAsText){
+              replacement += "\uFE0E";
+          }
           result = result.replace(
             ":" + candidate.fullString + ":",
             replacement
@@ -125,8 +146,9 @@ public class EmojiParser {
 
     // Replace the html
     for (Emoji emoji : EmojiManager.getAll()) {
-      result = result.replace(emoji.getHtmlHexadecimal(), emoji.getUnicode());
-      result = result.replace(emoji.getHtmlDecimal(), emoji.getUnicode());
+      String replacement = parseAsText ? emoji.getAsText() : emoji.getUnicode();
+      result = result.replace(emoji.getHtmlHexadecimal(), replacement);
+      result = result.replace(emoji.getHtmlDecimal(), replacement);
     }
 
     return result;

--- a/src/test/java/com/vdurmont/emoji/EmojiParserTest.java
+++ b/src/test/java/com/vdurmont/emoji/EmojiParserTest.java
@@ -319,6 +319,19 @@ public class EmojiParserTest {
   }
 
   @Test
+  public void parseToUnicode_with_as_text_set_to_true() {
+    // GIVEN
+    String str = ":boy:";
+
+    // WHEN
+    String result = EmojiParser.parseToUnicode(str, true);
+    String expected = "\uD83D\uDC66\uFE0E";
+
+    // THEN
+    assertEquals(expected, result);
+  }
+
+  @Test
   public void getAliasCanditates_with_one_alias() {
     // GIVEN
     String str = "test :candidate: test";


### PR DESCRIPTION
Add API to force rendering emojis as text

Details: http://mts.io/2015/04/21/unicode-symbol-render-text-emoji/

Fix #49