### PR TITLE
Updated the Json Library version in the dependency list.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,11 +38,13 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>20140107</version>
-        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.json/json -->
+	<dependency>
+    	    <groupId>org.json</groupId>
+    	    <artifactId>json</artifactId>
+    	    <version>20170516</version>
+	</dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,6 @@
     </properties>
 
     <dependencies>
-        <!-- https://mvnrepository.com/artifact/org.json/json -->
 	<dependency>
     	    <groupId>org.json</groupId>
     	    <artifactId>json</artifactId>


### PR DESCRIPTION
I found this library after a bit of a search, and wanted to use it in an Open-Source Android app called [Mastalab](https://bitbucket.org/tom79/mastodon_etalab), when including your version Android Studio moans about the version of Json conflicting with that shipped in Android.

I've updated the dependency, and now Android Studio no longer moans.

Thought you might want the update.