### PR TITLE
Fix HTML to unicode parse

### DIFF
--- a/src/main/java/com/vdurmont/emoji/EmojiManager.java
+++ b/src/main/java/com/vdurmont/emoji/EmojiManager.java
@@ -3,6 +3,8 @@ package com.vdurmont.emoji;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -41,6 +43,11 @@ public class EmojiManager {
       }
 
       EMOJI_TRIE = new EmojiTrie(emojis);
+      Collections.sort(ALL_EMOJIS, new Comparator<Emoji>() {
+        public int compare(Emoji e1, Emoji e2) {
+          return e2.getUnicode().length() - e1.getUnicode().length();
+        }
+      });
       stream.close();
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/src/test/java/com/vdurmont/emoji/EmojiJsonTest.java
+++ b/src/test/java/com/vdurmont/emoji/EmojiJsonTest.java
@@ -11,6 +11,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.*;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -47,12 +48,12 @@ public class EmojiJsonTest {
 
     @Ignore("1665 emoji still has not been added")
     @Test
-    public void checkEmojiExisting() throws Exception {
+    public void checkEmojiExisting() {
         assertTrue("Asserting for emoji: " + emoji, EmojiManager.isEmoji(emoji));
     }
 
     @Test
-    public void checkEmojiFitzpatricFlag() throws Exception {
+    public void checkEmojiFitzpatricFlag() {
         final int len = emoji.toCharArray().length;
         boolean shouldContainFitzpatric = false;
         int codepoint;
@@ -109,5 +110,14 @@ public class EmojiJsonTest {
             return Integer.parseInt(emojiCodepointAsString, 16);
         }
 
+    }
+
+    @Test
+    public void checkInverseParse() {
+        assertEquals(emoji, EmojiParser.parseToUnicode(EmojiParser.parseToHtmlDecimal(emoji, EmojiParser.FitzpatrickAction.IGNORE)));
+
+        assertEquals(emoji, EmojiParser.parseToUnicode(EmojiParser.parseToHtmlHexadecimal(emoji, EmojiParser.FitzpatrickAction.IGNORE)));
+
+        assertEquals(emoji, EmojiParser.parseToUnicode(EmojiParser.parseToAliases(emoji, EmojiParser.FitzpatrickAction.IGNORE)));
     }
 }


### PR DESCRIPTION
Fixes #80.

This PR sorts all emojis by their unicode length so that we always replace the longest matching HTML (hexa)decimal match first (to avoid :family_man_woman_girl_girl: being parsed to :man: :woman: :girl: :girl:)

Added a test to check that all emojis can be parsed to unicode and back, without sorting 70 emojis fail the test.