### PR TITLE
Capability to ignore parsing emoji aliases inside url links

### DIFF
--- a/src/test/java/com/vdurmont/emoji/EmojiParserTest.java
+++ b/src/test/java/com/vdurmont/emoji/EmojiParserTest.java
@@ -314,14 +314,14 @@ public class EmojiParserTest {
   @Test
   public void parseToUnicode_with_link_replaces_the_alias_by_the_emoji() {
     // GIVEN
-    String str = "hello :smiley:. The link is https://www.aaa.com/link_with_emoji_alias_:smiley:";
+    String str = ":smiley: The link is https://www.aaa.com/link_with_emoji_alias_:smiley:__:smiley: hello :smiley:.";
 
     // WHEN
     String result = EmojiParser.parseToUnicode(str, true);
 
     // THEN
     assertEquals(
-        "hello 😃. The link is https://www.aaa.com/link_with_emoji_alias_:smiley:",
+        "😃 The link is https://www.aaa.com/link_with_emoji_alias_:smiley:__:smiley: hello 😃.",
         result
     );
 
@@ -416,9 +416,9 @@ public class EmojiParserTest {
 
     // THEN
     assertEquals(2, candidates.size());
-    assertEquals("candi", candidates.get(0).alias);
+    assertEquals("candi", candidates.get(1).alias);
     assertNull(candidates.get(0).fitzpatrick);
-    assertEquals("candidate", candidates.get(1).alias);
+    assertEquals("candidate", candidates.get(0).alias);
     assertNull(candidates.get(1).fitzpatrick);
   }
 
@@ -432,9 +432,9 @@ public class EmojiParserTest {
 
     // THEN
     assertEquals(2, candidates.size());
-    assertEquals("candi", candidates.get(0).alias);
+    assertEquals("candi", candidates.get(1).alias);
     assertNull(candidates.get(0).fitzpatrick);
-    assertEquals("candidate", candidates.get(1).alias);
+    assertEquals("candidate", candidates.get(0).alias);
     assertNull(candidates.get(1).fitzpatrick);
   }
 


### PR DESCRIPTION
# Description
Taking the following string as example:
`hello :smiley:. The link is https://link_with_emoji_alias_:smiley:_that_we_do_not_want_to_replace`

Currently parsing the above string to unicode will become:
`hello 😃. The link is https://link_with_emoji_alias_😃_that_we_do_not_want_to_replace`

Added a new method `parseToUnicode(String input, boolean shouldIgnoreUrls)` that will allow us to ignore the parsing inside urls.

The result will be a not broken link:
`hello 😃. The link is https://link_with_emoji_alias_:smiley:_that_we_do_not_want_to_replace`
