### PR TITLE
Support for Apple's Encoding

### DIFF
--- a/src/test/java/com/vdurmont/emoji/EmojiParserTest.java
+++ b/src/test/java/com/vdurmont/emoji/EmojiParserTest.java
@@ -449,7 +449,7 @@ public class EmojiParserTest {
   public void removeAllEmojis_removes_all_the_emojis_from_the_string() {
     // GIVEN
     String input = "An 😀awesome 😃string 😄with " +
-      "a \uD83D\uDC66\uD83C\uDFFFfew 😉emojis!";
+      "a \uD83D\uDC66\uD83C\uDFFFfew 😉emojis!👩‍🚀🏿👩🏿‍🚀";
 
     // WHEN
     String result = EmojiParser.removeAllEmojis(input);


### PR DESCRIPTION
### Problem
When using Apple's emoji input ([control]+[command]+[space]), emojis are apparently encoded differently from what the library expects. For instance, 👩🏿‍🚀 is encoded as follows:
- `\uD83D\uDC69` = \<woman\> = 👩
- `\uD83C\uDFFF` = \<fitzpatrick modifier\> = 🏿 
- `\u200D` = \<joiner\>
- `\uD83D\uDE80` = \<rocket\> = 🚀

In contrast to that, as defined in [emojis.json:14422](https://github.com/vdurmont/emoji-java/blob/master/src/main/resources/emojis.json#L14422) the library expects:
- `\uD83D\uDC69` = \<woman\> = 👩
- `\u200D` = \<joiner\>
- `\uD83D\uDE80` = \<rocket\> = 🚀
- `\uD83C\uDFFF` = \<fitzpatrick modifier\> = 🏿 

Consequently, the library will detect some emojis entered via Apple's emoji input as two emojis, and `EmojiParser.removeAllEmojis(String)` will leave the joiner `\u200D`. Consider the following code:

```Java
import com.vdurmont.emoji.EmojiParser;

import java.util.List;

public class EmojiTest {
    public static void main(String[] args) {
        String test = "👩🏿‍🚀";

        char[] chars = EmojiParser.removeAllEmojis(test).toCharArray();
        for (int i = 0; i < chars.length; ++i)
            System.out.println(i + ": " + Integer.toHexString(chars[i]));

        List<String> emojis = EmojiParser.extractEmojis(test);
        System.out.println(emojis);
    }
}
```

Its output is:

```
0: 200d
[👩, 🚀]
```

### Solution

I am not quite sure which of the two encodings is the correct/official/preferable one. In order to quickly solve this issue, I would suggest to extend the library to simply support Apple's encoding as well.

Consequently, I would extend`EmojiParser.getUnicodeCandidates(String)` to check for a joiner char `\u200D` after every `UnicodeCandidate`. If found, and if the following chars also represent an emoji, the two char sequences are combined, but without modifiers. If this fused char sequence also represents an emoji, the candidate is extended, and the modifier is re-applied. In other words: An Apple-like sequence \<emoji\>\<modifier\>\<joiner\>\<emoji\> should be reshuffled to \<emoji\>\<joiner\>\<emoji\>\<modifier\> during parsing.