### PR TITLE
Make getUnicodeCandidates public

### DIFF
--- a/src/main/java/com/vdurmont/emoji/EmojiParser.java
+++ b/src/main/java/com/vdurmont/emoji/EmojiParser.java
@@ -395,7 +395,7 @@ public class EmojiParser {
    * @param input String to find all unicode emojis in
    * @return List of UnicodeCandidates for each unicode emote in text
    */
-  protected static List<UnicodeCandidate> getUnicodeCandidates(String input) {
+  public static List<UnicodeCandidate> getUnicodeCandidates(String input) {
     char[] inputCharArray = input.toCharArray();
     List<UnicodeCandidate> candidates = new ArrayList<UnicodeCandidate>();
     UnicodeCandidate next;


### PR DESCRIPTION
Calling `extractEmojis` only returns a list of strings. In order to provide more information about emojis found, access to the `UnicodeCandidate`s would be useful. Changing the `getUnicodeCandidates` method from `protected` to `public` makes this possible and should have little impact.