### PR TITLE
Performance improvements

### DIFF
--- a/src/main/java/com/vdurmont/emoji/EmojiManager.java
+++ b/src/main/java/com/vdurmont/emoji/EmojiManager.java
@@ -23,7 +23,7 @@ public class EmojiManager {
   private static final Map<String, Set<Emoji>> EMOJIS_BY_TAG =
     new HashMap<String, Set<Emoji>>();
   private static final List<Emoji> ALL_EMOJIS;
-  private static final EmojiTrie EMOJI_TRIE;
+  static final EmojiTrie EMOJI_TRIE;
 
   static {
     try {

--- a/src/main/java/com/vdurmont/emoji/EmojiManager.java
+++ b/src/main/java/com/vdurmont/emoji/EmojiManager.java
@@ -83,21 +83,17 @@ public class EmojiManager {
    * is unknown
    */
   public static Emoji getForAlias(String alias) {
-    if (alias == null) {
+    if (alias == null || alias.isEmpty()) {
       return null;
     }
     return EMOJIS_BY_ALIAS.get(trimAlias(alias));
   }
 
   private static String trimAlias(String alias) {
-    String result = alias;
-    if (result.startsWith(":")) {
-      result = result.substring(1, result.length());
-    }
-    if (result.endsWith(":")) {
-      result = result.substring(0, result.length() - 1);
-    }
-    return result;
+    int len = alias.length();
+    return alias.substring(
+            alias.charAt(0) == ':' ? 1 : 0,
+            alias.charAt(len - 1) == ':' ? len - 1 : len);
   }
 
 

--- a/src/main/java/com/vdurmont/emoji/EmojiParser.java
+++ b/src/main/java/com/vdurmont/emoji/EmojiParser.java
@@ -1,7 +1,6 @@
 package com.vdurmont.emoji;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -456,11 +455,7 @@ public class EmojiParser {
   protected static int getEmojiEndPos(char[] text, int startPos) {
     int best = -1;
     for (int j = startPos + 1; j <= text.length; j++) {
-      EmojiTrie.Matches status = EmojiManager.isEmoji(Arrays.copyOfRange(
-        text,
-        startPos,
-        j
-      ));
+      EmojiTrie.Matches status = EmojiManager.EMOJI_TRIE.isEmoji(text, startPos, j);
 
       if (status.exactMatch()) {
         best = j;

--- a/src/main/java/com/vdurmont/emoji/EmojiTrie.java
+++ b/src/main/java/com/vdurmont/emoji/EmojiTrie.java
@@ -5,12 +5,16 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class EmojiTrie {
-  private Node root = new Node();
+  private final Node root = new Node();
+  final int maxDepth;
 
   public EmojiTrie(Collection<Emoji> emojis) {
+    int maxDepth = 0;
     for (Emoji emoji : emojis) {
       Node tree = root;
-      for (char c: emoji.getUnicode().toCharArray()) {
+      char[] chars = emoji.getUnicode().toCharArray();
+      maxDepth = Math.max(maxDepth, chars.length);
+      for (char c: chars) {
         if (!tree.hasChild(c)) {
           tree.addChild(c);
         }
@@ -18,6 +22,7 @@ public class EmojiTrie {
       }
       tree.setEmoji(emoji);
     }
+    this.maxDepth = maxDepth;
   }
 
 

--- a/src/main/java/com/vdurmont/emoji/EmojiTrie.java
+++ b/src/main/java/com/vdurmont/emoji/EmojiTrie.java
@@ -40,16 +40,29 @@ public class EmojiTrie {
    * &lt;/li&gt;
    */
   public Matches isEmoji(char[] sequence) {
+    return isEmoji(sequence, 0, sequence.length);
+  }
+
+  /**
+   * Checks if the sequence of chars within the given bound indices contain an emoji.
+   * @see #isEmoji(char[])
+   */
+  public Matches isEmoji(char[] sequence, int start, int end) {
+    if (start < 0 || start > end || end > sequence.length) {
+      throw new ArrayIndexOutOfBoundsException(
+              "start " + start + ", end " + end + ", length " + sequence.length);
+    }
+
     if (sequence == null) {
       return Matches.POSSIBLY;
     }
 
     Node tree = root;
-    for (char c : sequence) {
-      if (!tree.hasChild(c)) {
+    for (int i = start; i < end; i++) {
+      if (!tree.hasChild(sequence[i])) {
         return Matches.IMPOSSIBLE;
       }
-      tree = tree.getChild(c);
+      tree = tree.getChild(sequence[i]);
     }
 
     return tree.isEndOfEmoji() ? Matches.EXACTLY : Matches.POSSIBLY;
@@ -62,12 +75,21 @@ public class EmojiTrie {
    * @return Emoji instance if unicode matches and emoji, null otherwise.
    */
   public Emoji getEmoji(String unicode) {
+    return getEmoji(unicode.toCharArray(), 0, unicode.length());
+  }
+
+  Emoji getEmoji(char[] sequence, int start, int end) {
+    if (start < 0 || start > end || end > sequence.length) {
+      throw new ArrayIndexOutOfBoundsException(
+              "start " + start + ", end " + end + ", length " + sequence.length);
+    }
+
     Node tree = root;
-    for (char c : unicode.toCharArray()) {
-      if (!tree.hasChild(c)) {
+    for (int i = 0; i < end; i++) {
+      if (!tree.hasChild(sequence[i])) {
         return null;
       }
-      tree = tree.getChild(c);
+      tree = tree.getChild(sequence[i]);
     }
     return tree.getEmoji();
   }

--- a/src/test/java/com/vdurmont/emoji/EmojiParserTest.java
+++ b/src/test/java/com/vdurmont/emoji/EmojiParserTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnit4.class)
 public class EmojiParserTest {
@@ -335,105 +336,71 @@ public class EmojiParserTest {
   }
 
   @Test
-  public void getAliasCanditates_with_one_alias() {
+  public void getAliasAt_with_one_alias() {
     // GIVEN
-    String str = "test :candidate: test";
+    String str = "test :boy: test";
 
     // WHEN
-    List<AliasCandidate> candidates = EmojiParser.getAliasCandidates(str);
+    AliasCandidate candidate = EmojiParser.getAliasAt(str, 5);
 
     // THEN
-    assertEquals(1, candidates.size());
-    assertEquals("candidate", candidates.get(0).alias);
-    assertNull(candidates.get(0).fitzpatrick);
+    assertTrue(candidate.emoji.getAliases().contains("boy"));
+    assertNull(candidate.fitzpatrick);
   }
 
   @Test
-  public void getAliasCanditates_with_one_alias_an_another_colon_after() {
+  public void getAliasAt_with_one_alias_an_another_colon_after() {
     // GIVEN
-    String str = "test :candidate: test:";
+    String str = "test :boy: test:";
 
     // WHEN
-    List<AliasCandidate> candidates = EmojiParser.getAliasCandidates(str);
+    AliasCandidate candidate = EmojiParser.getAliasAt(str, 5);
 
     // THEN
-    assertEquals(1, candidates.size());
-    assertEquals("candidate", candidates.get(0).alias);
-    assertNull(candidates.get(0).fitzpatrick);
+    assertTrue(candidate.emoji.getAliases().contains("boy"));
+    assertNull(candidate.fitzpatrick);
   }
 
   @Test
-  public void getAliasCanditates_with_one_alias_an_another_colon_right_after() {
+  public void getAliasAt_with_one_alias_an_another_colon_right_after() {
     // GIVEN
-    String str = "test :candidate::test";
+    String str = "test :boy::test";
 
     // WHEN
-    List<AliasCandidate> candidates = EmojiParser.getAliasCandidates(str);
+    AliasCandidate candidate = EmojiParser.getAliasAt(str, 5);
 
     // THEN
-    assertEquals(1, candidates.size());
-    assertEquals("candidate", candidates.get(0).alias);
-    assertNull(candidates.get(0).fitzpatrick);
+    assertTrue(candidate.emoji.getAliases().contains("boy"));
+    assertNull(candidate.fitzpatrick);
   }
 
   @Test
-  public void getAliasCanditates_with_one_alias_an_another_colon_before_after() {
+  public void getAliasAt_with_one_alias_an_another_colon_before_after() {
     // GIVEN
-    String str = "test ::candidate: test";
+    String str = "test ::boy: test";
 
     // WHEN
-    List<AliasCandidate> candidates = EmojiParser.getAliasCandidates(str);
+    AliasCandidate candidate = EmojiParser.getAliasAt(str, 5);
+    assertNull(candidate);
+
+    candidate = EmojiParser.getAliasAt(str, 6);
 
     // THEN
-    assertEquals(1, candidates.size());
-    assertEquals("candidate", candidates.get(0).alias);
-    assertNull(candidates.get(0).fitzpatrick);
+    assertTrue(candidate.emoji.getAliases().contains("boy"));
+    assertNull(candidate.fitzpatrick);
   }
 
   @Test
-  public void getAliasCanditates_with_two_aliases() {
+  public void getAliasAt_with_a_fitzpatrick_modifier() {
     // GIVEN
-    String str = "test :candi: :candidate: test";
+    String str = "test :boy|type_3: test";
 
     // WHEN
-    List<AliasCandidate> candidates = EmojiParser.getAliasCandidates(str);
+    AliasCandidate candidate = EmojiParser.getAliasAt(str, 5);
 
     // THEN
-    assertEquals(2, candidates.size());
-    assertEquals("candi", candidates.get(0).alias);
-    assertNull(candidates.get(0).fitzpatrick);
-    assertEquals("candidate", candidates.get(1).alias);
-    assertNull(candidates.get(1).fitzpatrick);
-  }
-
-  @Test
-  public void getAliasCanditates_with_two_aliases_sharing_a_colon() {
-    // GIVEN
-    String str = "test :candi:candidate: test";
-
-    // WHEN
-    List<AliasCandidate> candidates = EmojiParser.getAliasCandidates(str);
-
-    // THEN
-    assertEquals(2, candidates.size());
-    assertEquals("candi", candidates.get(0).alias);
-    assertNull(candidates.get(0).fitzpatrick);
-    assertEquals("candidate", candidates.get(1).alias);
-    assertNull(candidates.get(1).fitzpatrick);
-  }
-
-  @Test
-  public void getAliasCanditates_with_a_fitzpatrick_modifier() {
-    // GIVEN
-    String str = "test :candidate|type_3: test";
-
-    // WHEN
-    List<AliasCandidate> candidates = EmojiParser.getAliasCandidates(str);
-
-    // THEN
-    assertEquals(1, candidates.size());
-    assertEquals("candidate", candidates.get(0).alias);
-    assertEquals(Fitzpatrick.TYPE_3, candidates.get(0).fitzpatrick);
+    assertTrue(candidate.emoji.getAliases().contains("boy"));
+    assertEquals(Fitzpatrick.TYPE_3, candidate.fitzpatrick);
   }
 
   @Test


### PR DESCRIPTION
This should fix the issues outlined in #116.

I had trouble getting stable and accurate metrics for memory usage, but I did include metrics for runtime execution. All tests results are average milliseconds of 5 runs with 1 warmup round that is not counted.

100k random tweets:

Method | e867585 | 6bc16b7 | Δ e867585 | 25a6d91 | Δ e867585
-- | -- | -- | -- | -- | --
parseToAliases | 228.63 | 232.88 | 1.86% | 128.76 | -43.68%
parseToHtmlDecimal | 234.51 | 224.61 | -4.22% | 126.83 | -45.91%
parseToHtmlHexadecimal | 239.59 | 225.80 | -5.76% | 125.51 | -47.62%
removeAllEmojis | 234.01 | 214.23 | -8.45% | 128.81 | -44.96%
parseToUnicode | 6611.55 | 99.26 | -98.50% | 86.75 | -98.69%

Same 100k tweets from previous test, but with ~350k HTML encoded emojis inserted into ~83k/100k of the tweets. 

Method | e867585 | 6bc16b7 | Δ e867585 | 25a6d91 | Δ e867585
-- | -- | -- | -- | -- | --
parseToAliases | 349.58 | 343.24 | -1.81% | 191.25 | -45.29%
parseToHtmlDecimal | 345.90 | 384.49 | 11.16% | 193.41 | -44.09%
parseToHtmlHexadecimal | 336.58 | 357.78 | 6.30% | 213.58 | -36.54%
removeAllEmojis | 354.79 | 329.84 | -7.03% | 210.94 | -40.55%
parseToUnicode | 10438.70 | 4721.01 | -54.77% | 209.65 | -97.99%


To sum up, it speeds up `parseToUnicode()` by about 50 times and the four from-unicode methods by a factor of 2. The improvement for the from-unicode methods is mostly due to avoiding copying the char array when searching for emoji end.