### PR TITLE
I would like to add it to the emoji pager policy. - 🦾

### DIFF
--- a/src/main/resources/emojis.json
+++ b/src/main/resources/emojis.json
@@ -16802,5 +16802,14 @@
       "jolly_roger"
     ],
     "tags": []
+  },
+  {
+    "emojiChar": "🦾",
+    "emoji": "\uD83E\uDDBE",
+    "description": "machine arm",
+    "aliases": [
+      "machine arm"
+    ],
+    "tags": []
   }
 ]


### PR DESCRIPTION
Hello. No removal is being done for the emoji (🦾).

There is no information about emoji at the link below.
https://github.com/vdurmont/emoji-java/blob/master/src/main/resources/emojis.json

Can you add it?