### PR TITLE
Fixing mci bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ _The missing emoji library for java._
 </dependency>
 ```
 
-You can also download the project, build it with `mvn clean install` and add the generated jar to your buildpath.
+You can also download the project, build it with `mvn package` and add the generated jar to your buildpath.
 
 ##### Via Gradle:
 


### PR DESCRIPTION
Well, with `clean` you delete the project cache of Maven which makes the build much slower. With `install`, the artifact will be copied to the `~/.m2` directory, which you don't want in this case. You want just to build the artifact, so `mvn package` is the correct command…

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vdurmont/emoji-java/163)
<!-- Reviewable:end -->
