### PR TITLE
added discord alias for "e-mail symbol"

### DIFF
--- a/src/main/resources/emojis.json
+++ b/src/main/resources/emojis.json
@@ -7331,7 +7331,8 @@
     "emoji": "\uD83D\uDCE7",
     "description": "e-mail symbol",
     "aliases": [
-      "e-mail"
+      "e-mail",
+      "e_mail"
     ],
     "tags": []
   },


### PR DESCRIPTION
Discord uses ":e_mail:" instead of ":e-mail:"