### PR TITLE
Upgrade the json dependency to version 20220924

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20170516</version>
+            <version>20220924</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Update the json dependency version from 20170516 to 20220924, because the older version has a vulnerability.

Reference: https://ossindex.sonatype.org/component/pkg:maven/org.json/json@20170516?utm_source=ossindex-client&utm_medium=integration&utm_content=1.7.0

**Fix till this PR is merged:**

```
implementation("com.vdurmont:emoji-java:5.1.1")
constraints {
    implementation("org.json:json:20220924") {
        because("version 20170516 is affected by some vulnerability")
    }
}
```